### PR TITLE
updated complete state of workflow

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -24,7 +24,7 @@ const displayStatsData = (displayState, onClickAction) => (
 
 export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
     const buttonAppearance = (
-        workflow.currentTask.details.complete
+        workflow.navigatorUiVariables.taskComplete
             ? {
                 label: 'Task Complete',
                 variant: 'outline-success',

--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -23,10 +23,8 @@ const displayStatsData = (displayState, onClickAction) => (
 )
 
 export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
-    const isLatestTask = [...workflow.taskBreadcrumbs].pop() === workflow.currentTask.id;
-    const complete = !(isLatestTask || workflow.currentTask.skipped);
     const buttonAppearance = (
-        complete
+        workflow.currentTask.details.complete
             ? {
                 label: 'Task Complete',
                 variant: 'outline-success',

--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -23,8 +23,10 @@ const displayStatsData = (displayState, onClickAction) => (
 )
 
 export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
+    const isLatestTask = [...workflow.taskBreadcrumbs].pop() === workflow.currentTask.id;
+    const complete = !(isLatestTask || workflow.currentTask.skipped);
     const buttonAppearance = (
-        workflow.currentTask.details.complete
+        complete
             ? {
                 label: 'Task Complete',
                 variant: 'outline-success',

--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -8,7 +8,8 @@ import {
     taskCompleteCheckbox,
     priorTaskButton,
     nextTaskButton,
-    whatsNextButton
+    whatsNextButton,
+    getWorkflowStats
 } from '../lib/actionButtons';
 
 const displayStatsData = (displayState, onClickAction) => (
@@ -23,8 +24,9 @@ const displayStatsData = (displayState, onClickAction) => (
 )
 
 export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
+    const { complete } = getWorkflowStats(workflow);
     const buttonAppearance = (
-        workflow.navigatorUiVariables.taskComplete
+        complete
             ? {
                 label: 'Task Complete',
                 variant: 'outline-success',

--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -8,7 +8,7 @@ export const actions = {
   toggleCompleteStateLocally: 'toggleCompleteStateLocally'
 }
 
-function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
+export function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
   const { id: currentTaskId, manual } = currentTask;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;
   const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;

--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -10,9 +10,9 @@ export const actions = {
 
 function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
   const { id: currentTaskId, manual } = currentTask;
-  const complete = currentTask.details.complete;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;
   const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;
+  const complete = !(isLatestTask || currentTask.skipped);
   return { currentTaskId, complete, manual, isOldestTask, isLatestTask }
 }
 

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -15,32 +15,20 @@ describe('The "Task Complete" button should', () => {
         describe('and is set to manual', () => {
             const manual = true;
             test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
-                const complete = false;
                 const checked = false;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
                         onClickAction: actions.markTaskAsComplete
                     });
             });
-            test('and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action', () => {
-                const complete = true;
-                const checked = true;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({
-                        enabled, checked,
-                        onClickAction: actions.markTaskAsIncomplete
-                    });
-            });
         });
         describe('and is set to not manual', () => {
             const manual = false;
             test('and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action', () => {
-                const complete = false;
                 const checked = false;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -55,9 +43,8 @@ describe('The "Task Complete" button should', () => {
             const enabled = true;
             const manual = true;
             test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
-                const complete = false;
                 const checked = false;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, skipped: true }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -65,9 +52,8 @@ describe('The "Task Complete" button should', () => {
                     });
             });
             test('and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action', () => {
-                const complete = true;
                 const checked = true;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, skipped: false }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -79,16 +65,14 @@ describe('The "Task Complete" button should', () => {
             const enabled = false;
             const manual = false;
             test('and is incomplete, should return an disabled unchecked button', () => {
-                const complete = false;
                 const checked = false;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, skipped: true }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({ enabled, checked, onClickAction: null });
             });
             test('and is complete, should return an disabled checked button', () => {
-                const complete = true;
                 const checked = true;
-                const workflowState = { currentTask: { id, manual, details: { complete } }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, skipped: false }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({ enabled, checked, onClickAction: null });
             });
@@ -97,12 +81,11 @@ describe('The "Task Complete" button should', () => {
 });
 
 describe('The "Prior Task" button should', () => {
-    const details = { complete: null };
     describe('If the task is set to manual', () => {
         const manual = true;
         test('and if !isOldestTask in the breadcrumbs, should return an enabled button with the getPreviousTask onclick action', () => {
             const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({
                     enabled: true,
@@ -111,7 +94,7 @@ describe('The "Prior Task" button should', () => {
         });
         test('and if isOldestTask in the breadcrumbs, should return a disabled button', () => {
             const taskBreadcrumbs = ['task1', 'task2'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({ enabled: false, onClickAction: null });
         });
@@ -120,7 +103,7 @@ describe('The "Prior Task" button should', () => {
         const manual = false;
         test('and if breadcrumbs length > 1, should return an enabled button with the getPreviousTask onclick action', () => {
             const taskBreadcrumbs = ['task0', 'task1'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({
                     enabled: true,
@@ -129,7 +112,7 @@ describe('The "Prior Task" button should', () => {
         });
         test('and if breadcrumbs length <= 1, should return a disabled button', () => {
             const taskBreadcrumbs = ['task1'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({ enabled: false, onClickAction: null });
         });
@@ -137,16 +120,15 @@ describe('The "Prior Task" button should', () => {
 });
 
 describe('The "Next Task" button should', () => {
-    const details = { complete: null };
     test('If the task isLatestTask in the breadcrumbs, should return an disabled button', () => {
         const taskBreadcrumbs = ['task0', 'task1'];
-        const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id }, taskBreadcrumbs };
         expect(nextTaskButton(workflowState))
             .toStrictEqual({ enabled: false, onClickAction: null });
     });
     test('If the task !isLatestTask in the breadcrumbs, should return an enabled button with the onclick getNextTask action', () => {
         const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-        const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id }, taskBreadcrumbs };
         expect(nextTaskButton(workflowState))
             .toStrictEqual({
                 enabled: true,
@@ -157,9 +139,8 @@ describe('The "Next Task" button should', () => {
 
 describe('The "What\'s Next" button should', () => {
     test('If the task is complete, should return an enabled button with the onclick [fetchLatestWorkflowState] actions', () => {
-        const complete = true;
-        const taskBreadcrumbs = ['task0', 'task1'];
-        const workflowState = { currentTask: { id, details: { complete } }, taskBreadcrumbs };
+        const taskBreadcrumbs = ['task1', 'task2'];
+        const workflowState = { currentTask: { id, skipped: false }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toStrictEqual({
                 enabled: true,
@@ -167,9 +148,8 @@ describe('The "What\'s Next" button should', () => {
             });
     });
     test('If the task is incomplete, should return an enabled button with the onclick skipTaskAndFetchLatestWorkflowState actions', () => {
-        const complete = false;
-        const taskBreadcrumbs = ['task0', 'task1'];
-        const workflowState = { currentTask: { id, details: { complete } }, taskBreadcrumbs };
+        const taskBreadcrumbs = ['task0', 'task1', 'task2'];
+        const workflowState = { currentTask: { id, skipped: true }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toStrictEqual({
                 enabled: true,

--- a/pages/index.js
+++ b/pages/index.js
@@ -28,18 +28,10 @@ export default function Index(props) {
   const [{ loading, error }, makeApiRequest] = useAxios(
     null, { manual: true }
   );
-  function addNavigatorUiVariables(workflow) {
-    const { currentTask, taskBreadcrumbs } = workflow;
-    const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;
-    const navigatorUiVariables = {
-      taskComplete: !(isLatestTask || currentTask.skipped)
-    };
-    return { ...workflow, navigatorUiVariables }
-  }
   async function fetchWorkflow() {
     makeApiRequest(
       getWorkflow(props.currentDatasetId)
-    ).then(res => setWorkflow(addNavigatorUiVariables(res.data)))
+    ).then(res => setWorkflow(res.data))
   }
 
   useEffect(() => {
@@ -50,7 +42,7 @@ export default function Index(props) {
     const updateWorkflowComplete = (complete, postToApi) => {
       function updateLocalState() {
         let updatedWorkflow = { ...workflow };
-        updatedWorkflow.navigatorUiVariables.taskComplete = complete;
+        updatedWorkflow.currentTask.skipped = !complete;
         setWorkflow(updatedWorkflow)
       }
       if (postToApi) {
@@ -100,7 +92,7 @@ export default function Index(props) {
     } else if (actionToCarryOut === actions.fetchLatestWorkflowState) {
       fetchWorkflow();
     } else if (actionToCarryOut === actions.toggleCompleteStateLocally) {
-      updateWorkflowComplete(!workflow.navigatorUiVariables.taskComplete, false);
+      updateWorkflowComplete(!workflow.currentTask.skipped, false);
     } else {
       throw new Error([`Unknown action: ${actionToCarryOut}`])
     }
@@ -164,7 +156,7 @@ export default function Index(props) {
               <Col xs={3} className="d-flex align-items-end flex-column">
                 <div className="mt-auto">
                   <TaskCompleteCheckbox
-                    workflow={workflow}
+                    workflow={{ currentTask, taskBreadcrumbs }}
                     handleClick={carryOutActions}
                     displayState={displayState}
                   />
@@ -228,7 +220,7 @@ export default function Index(props) {
       {displayState && (
         <>
           <hr />
-          <pre style={{ fontSize: 10 }}>{JSON.stringify(workflow, null, 3)}</pre>
+          <pre style={{ fontSize: 10 }}>{JSON.stringify({ workflow, props }, null, 3)}</pre>
         </>
       )}
     </Layout>


### PR DESCRIPTION
To set the `complete` state of a workflow we need to
- stop using `currentTask.details.complete`
- Use `!(isLatestTask || currentTask.skipped)` instead
