### PR TITLE
NAV-145-better-debug-and-error-data

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -1,4 +1,4 @@
-import { ButtonGroup, OverlayTrigger, Button, Tooltip } from 'react-bootstrap';
+import { ButtonGroup, Button } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSquare } from '@fortawesome/free-regular-svg-icons';
 import {
@@ -43,21 +43,16 @@ export function TaskCompleteCheckbox({ workflow, handleClick, showDebugData }) {
         ...buttonAppearance,
         ...taskCompleteCheckbox(workflow)
     }
-    const overlay = <Tooltip>This task is automatically set by the system</Tooltip>
     return (
-        <OverlayTrigger overlay={overlay}>
-            <span className="d-inline-block">
-                <Button
-                    variant={button.variant}
-                    onClick={() => handleClick(button.onClickAction)}
-                    disabled={button.enabled}
-                >
-                    <span>{button.label}</span>
-                    <FontAwesomeIcon icon={button.icon} className="ms-2" />
-                    {button.onClickAction && displayStatsData(showDebugData, button.onClickAction)}
-                </Button>
-            </span>
-        </OverlayTrigger>
+        <Button
+            variant={button.variant}
+            onClick={() => handleClick(button.onClickAction)}
+            disabled={!button.enabled}
+        >
+            <span>{button.label}</span>
+            <FontAwesomeIcon icon={button.icon} className="ms-2" />
+            {button.onClickAction && displayStatsData(showDebugData, button.onClickAction)}
+        </Button>
     )
 }
 

--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -1,4 +1,4 @@
-import { ButtonGroup, Button } from 'react-bootstrap';
+import { ButtonGroup, OverlayTrigger, Button, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSquare } from '@fortawesome/free-regular-svg-icons';
 import {
@@ -13,9 +13,9 @@ import {
     getWorkflowStats
 } from '../lib/actionButtons';
 
-const displayStatsData = (displayState, onClickAction) => (
+const displayStatsData = (showDebugData, onClickAction) => (
     <>
-        {displayState &&
+        {showDebugData &&
             <div>
                 <hr />
                 <p>{onClickAction}</p>
@@ -24,7 +24,7 @@ const displayStatsData = (displayState, onClickAction) => (
     </>
 )
 
-export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
+export function TaskCompleteCheckbox({ workflow, handleClick, showDebugData }) {
     const { complete } = getWorkflowStats(workflow);
     const buttonAppearance = (
         complete
@@ -43,20 +43,25 @@ export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
         ...buttonAppearance,
         ...taskCompleteCheckbox(workflow)
     }
+    const overlay = <Tooltip>This task is automatically set by the system</Tooltip>
     return (
-        <Button
-            variant={button.variant}
-            onClick={() => handleClick(button.onClickAction)}
-            disabled={!button.enabled}
-        >
-            <span>{button.label}</span>
-            <FontAwesomeIcon icon={button.icon} className="ms-2" />
-            {button.onClickAction && displayStatsData(displayState, button.onClickAction)}
-        </Button>
+        <OverlayTrigger overlay={overlay}>
+            <span className="d-inline-block">
+                <Button
+                    variant={button.variant}
+                    onClick={() => handleClick(button.onClickAction)}
+                    disabled={button.enabled}
+                >
+                    <span>{button.label}</span>
+                    <FontAwesomeIcon icon={button.icon} className="ms-2" />
+                    {button.onClickAction && displayStatsData(showDebugData, button.onClickAction)}
+                </Button>
+            </span>
+        </OverlayTrigger>
     )
 }
 
-export function MainThreeActionButtons({ workflow, handleClick, displayState }) {
+export function MainThreeActionButtons({ workflow, handleClick, showDebugData }) {
     const buttons = [
         {
             label: "Prior Task",
@@ -86,7 +91,7 @@ export function MainThreeActionButtons({ workflow, handleClick, displayState }) 
                     >
                         <FontAwesomeIcon icon={button.icon} className="me-2" />
                         <span>{button.label}</span>
-                        {button.onClickAction && displayStatsData(displayState, button.onClickAction)}
+                        {button.onClickAction && displayStatsData(showDebugData, button.onClickAction)}
                     </Button>
                 </>
             )

--- a/components/ErrorPagePopup.js
+++ b/components/ErrorPagePopup.js
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Col, ButtonGroup, Button, Offcanvas } from 'react-bootstrap';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+    faExclamationCircle, faArrowsRotate
+} from '@fortawesome/free-solid-svg-icons';
+import LogsComponent from '../components/LogsComponent';
+
+export default function ErrorPagePopup({ apiError, workflow, props }) {
+    const [showJsonDump, setshowJsonDump] = useState(false);
+
+    const errorLogs = [
+        { title: 'API Error', data: apiError },
+        { title: 'workflow', data: workflow },
+        { title: 'props', data: props }
+    ];
+
+    return (
+        <Offcanvas show={true} placement="top" keyboard={false}>
+            <Offcanvas.Body>
+                <div className="text-center">
+                    <h4 className="text-danger">
+                        <FontAwesomeIcon icon={faExclamationCircle} className="me-2" />
+                        <span>Something went wrong, please refresh this page</span>
+                    </h4>
+                    <ButtonGroup size="sm" className="mt-2">
+                        <Button
+                            variant="danger"
+                            onClick={() => location.reload(true)}
+                        >
+                            <FontAwesomeIcon icon={faArrowsRotate} className="me-2" />
+                            <span>Refresh Page</span>
+                        </Button>
+                        <Button
+                            variant="light"
+                            onClick={() => setshowJsonDump(!showJsonDump)}
+                        >View Error Logs</Button>
+                    </ButtonGroup>
+                </div>
+                {showJsonDump && (
+                    <Col xs={{ span: 6, offset: 3 }}>
+                        <LogsComponent objects={errorLogs} />
+                    </Col>
+                )}
+            </Offcanvas.Body>
+        </Offcanvas>
+    )
+
+}

--- a/components/LogsComponent.js
+++ b/components/LogsComponent.js
@@ -1,0 +1,32 @@
+function LogComponent({ title, data }) {
+
+    const preStyle = {
+        fontSize: 10,
+        whiteSpace: 'pre-wrap'
+    }
+
+    return (
+        <>
+            <div className="shadow p-3 mt-5 bg-body rounded">
+                <h4 className="m-2 text-muted">{title}</h4>
+                <pre className="bg-light p-2 rounded" style={preStyle}>
+                    {JSON.stringify(data, null, 3)}
+                </pre>
+            </div>
+        </>
+    )
+
+}
+
+export default function LogsComponent({ objects }) {
+
+    return objects.map((object, index) => (
+        <div key={index}>
+            <LogComponent
+                title={object.title}
+                data={object.data}
+            />
+        </div>
+    ))
+
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,13 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Row, Col, ButtonToolbar, ListGroup, Offcanvas,
-  ProgressBar, Alert
+  Row, Col, Button, ButtonGroup, ButtonToolbar,
+  ListGroup, Offcanvas, ProgressBar, Alert
 } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleNotch, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCircleNotch, faExclamationCircle, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { Layout } from '../components/Layout'
 import DatasetSelector from '../components/DatasetSelector';
+import LogsComponent from '../components/LogsComponent';
 import MilestonesSidebar from '../components/MilestonesSidebar';
 import {
   TaskCompleteCheckbox,
@@ -23,7 +24,7 @@ import { actions } from '../lib/actionButtons';
 const useAxios = makeUseAxios(baseAxiosConfig)
 
 export default function Index(props) {
-  const [displayState, setDisplayState] = useState(false);
+  const [showDebugData, setshowDebugData] = useState(false);
   const [workflow, setWorkflow] = useState();
 
   const [{ loading, error }, makeApiRequest] = useAxios(
@@ -33,6 +34,44 @@ export default function Index(props) {
     makeApiRequest(
       getWorkflow(props.currentDatasetId)
     ).then(res => setWorkflow(res.data))
+  }
+  function ErrorPageComponent() {
+    const [showJsonDump, setshowJsonDump] = useState(false);
+    const errorLogs = [
+      { title: 'API Request', data: error },
+      { title: 'workflow', data: workflow },
+      { title: 'props', data: props }
+    ];
+    return (
+      <Offcanvas show={true} placement="top" keyboard={false}>
+        <Offcanvas.Body>
+          <div className="text-center">
+            <h4 className="text-danger">
+              <FontAwesomeIcon icon={faExclamationCircle} className="me-2" />
+              <span>Something went wrong, please refresh this page</span>
+            </h4>
+            <ButtonGroup size="sm" className="mt-2">
+              <Button
+                variant="danger"
+                onClick={() => location.reload(true)}
+              >
+                <FontAwesomeIcon icon={faArrowsRotate} className="me-2" />
+                <span>Refresh Page</span>
+              </Button>
+              <Button
+                variant="light"
+                onClick={() => setshowJsonDump(!showJsonDump)}
+              >View Error Logs</Button>
+            </ButtonGroup>
+          </div>
+          {showJsonDump && (
+            <Col xs={{ span: 6, offset: 3 }}>
+              <LogsComponent objects={errorLogs} />
+            </Col>
+          )}
+        </Offcanvas.Body>
+      </Offcanvas>
+    )
   }
 
   useEffect(() => {
@@ -161,7 +200,7 @@ export default function Index(props) {
                   <TaskCompleteCheckbox
                     workflow={{ currentTask, taskBreadcrumbs }}
                     handleClick={carryOutActions}
-                    displayState={displayState}
+                    showDebugData={showDebugData}
                   />
                 </div>
               </Col>
@@ -173,7 +212,7 @@ export default function Index(props) {
                   <div>Workflow {workflowId}</div>
                   <div>Task {currentTask.id}</div>
                   <div>
-                    <a onClick={() => setDisplayState(!displayState)}>Debug Mode</a>
+                    <a onClick={() => setshowDebugData(!showDebugData)}>Debug Mode</a>
                   </div>
                 </div>
               </Col>
@@ -182,7 +221,7 @@ export default function Index(props) {
                   <MainThreeActionButtons
                     workflow={{ currentTask, taskBreadcrumbs }}
                     handleClick={carryOutActions}
-                    displayState={displayState}
+                    showDebugData={showDebugData}
                   />
                 </ButtonToolbar>
               </Col>
@@ -212,19 +251,12 @@ export default function Index(props) {
           </h2>
         </Offcanvas.Body>
       </Offcanvas>
-      <Offcanvas show={error} placement="top" keyboard={false}>
-        <Offcanvas.Body className="text-center">
-          <h4 className="text-danger">
-            <FontAwesomeIcon icon={faExclamationCircle} className="me-2" />
-            <span>Something went wrong, please refresh this page</span>
-          </h4>
-        </Offcanvas.Body>
-      </Offcanvas>
-      {displayState && (
-        <>
-          <hr />
-          <pre style={{ fontSize: 10 }}>{JSON.stringify({ workflow, props }, null, 3)}</pre>
-        </>
+      {error && <ErrorPageComponent />}
+      {showDebugData && (
+        <LogsComponent objects={[
+          { title: 'workflow', data: workflow },
+          { title: 'props', data: props }
+        ]} />
       )}
     </Layout>
   )

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,18 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Row, Col, Button, ButtonGroup, ButtonToolbar,
-  ListGroup, Offcanvas, ProgressBar, Alert
+  Row, Col, ButtonToolbar, ListGroup, Offcanvas,
+  ProgressBar, Alert
 } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleNotch, faExclamationCircle, faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
+import { faCircleNotch } from '@fortawesome/free-solid-svg-icons';
 import { faLink } from '@fortawesome/free-solid-svg-icons';
 import { Layout } from '../components/Layout'
 import DatasetSelector from '../components/DatasetSelector';
 import LogsComponent from '../components/LogsComponent';
+import ErrorPagePopup from '../components/ErrorPagePopup';
 import MilestonesSidebar from '../components/MilestonesSidebar';
 import {
-  TaskCompleteCheckbox,
-  MainThreeActionButtons
+  TaskCompleteCheckbox, MainThreeActionButtons
 } from '../components/ActionButtons';
 import { makeUseAxios } from 'axios-hooks'
 import {
@@ -27,51 +27,13 @@ export default function Index(props) {
   const [showDebugData, setshowDebugData] = useState(false);
   const [workflow, setWorkflow] = useState();
 
-  const [{ loading, error }, makeApiRequest] = useAxios(
+  const [{ loading, error: apiError }, makeApiRequest] = useAxios(
     null, { manual: true }
   );
   async function fetchWorkflow() {
     makeApiRequest(
       getWorkflow(props.currentDatasetId)
     ).then(res => setWorkflow(res.data))
-  }
-  function ErrorPageComponent() {
-    const [showJsonDump, setshowJsonDump] = useState(false);
-    const errorLogs = [
-      { title: 'API Request', data: error },
-      { title: 'workflow', data: workflow },
-      { title: 'props', data: props }
-    ];
-    return (
-      <Offcanvas show={true} placement="top" keyboard={false}>
-        <Offcanvas.Body>
-          <div className="text-center">
-            <h4 className="text-danger">
-              <FontAwesomeIcon icon={faExclamationCircle} className="me-2" />
-              <span>Something went wrong, please refresh this page</span>
-            </h4>
-            <ButtonGroup size="sm" className="mt-2">
-              <Button
-                variant="danger"
-                onClick={() => location.reload(true)}
-              >
-                <FontAwesomeIcon icon={faArrowsRotate} className="me-2" />
-                <span>Refresh Page</span>
-              </Button>
-              <Button
-                variant="light"
-                onClick={() => setshowJsonDump(!showJsonDump)}
-              >View Error Logs</Button>
-            </ButtonGroup>
-          </div>
-          {showJsonDump && (
-            <Col xs={{ span: 6, offset: 3 }}>
-              <LogsComponent objects={errorLogs} />
-            </Col>
-          )}
-        </Offcanvas.Body>
-      </Offcanvas>
-    )
   }
 
   useEffect(() => {
@@ -251,7 +213,7 @@ export default function Index(props) {
           </h2>
         </Offcanvas.Body>
       </Offcanvas>
-      {error && <ErrorPageComponent />}
+      {apiError && <ErrorPagePopup {...{ apiError, workflow, props }} />}
       {showDebugData && (
         <LogsComponent objects={[
           { title: 'workflow', data: workflow },


### PR DESCRIPTION
https://fjelltopp.atlassian.net/browse/NAV-145

When you hit an API error we now display two buttons:
- One for the user to refresh the page
- Another for us to view debug data

![image](https://user-images.githubusercontent.com/2634482/143038661-4b0d4321-7655-449a-84c5-9bf2e8293083.png)

Clicking `View Error Logs` will show the api error:

![image](https://user-images.githubusercontent.com/2634482/143038856-97bd596a-4e47-448b-90d8-c8e6fab39164.png)

The same JSON viewer has also been used to update the `Debug Mode` section at the bottom of the page so the content wrapps and generally looks better.

![image](https://user-images.githubusercontent.com/2634482/143039028-9704a152-90ff-4ceb-ad75-ccc2ee8c6482.png)


Note: This PR looks huge as I renamed `displayState` to `showDebugData`