### PR TITLE
NAV-114-tooltip-on-disabled-complete-checkbox-btn

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -1,4 +1,4 @@
-import { ButtonGroup, Button } from 'react-bootstrap';
+import { ButtonGroup, Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSquare } from '@fortawesome/free-regular-svg-icons';
 import {
@@ -43,7 +43,7 @@ export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
         ...buttonAppearance,
         ...taskCompleteCheckbox(workflow)
     }
-    return (
+    const buttonComponent = (
         <Button
             variant={button.variant}
             onClick={() => handleClick(button.onClickAction)}
@@ -54,6 +54,23 @@ export function TaskCompleteCheckbox({ workflow, handleClick, displayState }) {
             {button.onClickAction && displayStatsData(displayState, button.onClickAction)}
         </Button>
     )
+    if (button.enabled) {
+        return buttonComponent;
+    } else {
+        const overlay = (
+            <Tooltip>
+                <p>Task status is automatically checked by system.</p>
+                <p>Click "What's Next" once task is complete.</p>
+            </Tooltip>
+        )
+        return (
+            <OverlayTrigger overlay={overlay}>
+                <span className="d-inline-block">
+                    {buttonComponent}
+                </span>
+            </OverlayTrigger>
+        )
+    }
 }
 
 export function MainThreeActionButtons({ workflow, handleClick, displayState }) {


### PR DESCRIPTION
If the `TaskCompleteCheckbox.enabled=false` then we should display a human readable tooltip explaining why

![image](https://user-images.githubusercontent.com/2634482/143045277-20907feb-1490-49a8-8ed3-497725005cdc.png)
