### PR TITLE
NAV-144-handle-all-api-errors

### DIFF
--- a/components/AuthWrapper.js
+++ b/components/AuthWrapper.js
@@ -4,6 +4,7 @@ import { makeUseAxios } from 'axios-hooks'
 import {
     baseAxiosConfig, getUserDetails, getDatasets,
 } from '../lib/api';
+import ErrorPagePopup from './ErrorPagePopup';
 
 const useAxios = makeUseAxios(baseAxiosConfig)
 
@@ -25,12 +26,14 @@ export default function AuthWrapper({ Component, pageProps }) {
     if (userDetailsLoading || datasetsLoading) {
         return <p>Loading...</p>
     } else if (userDetailsError || datasetsError) {
-        const statusCode = JSON.parse(JSON.stringify(userDetailsError)).status;
-        if (statusCode === 401) {
+        const invalidAuthError =
+            userDetailsError && userDetailsError.message.includes('401')
+            || datasetsError && datasetsError.message.includes('401')
+        if (invalidAuthError) {
             router.push('/login');
             return null;
         } else {
-            return <p>Unknown Server Error</p>
+            return <ErrorPagePopup apiError={userDetailsError || datasetsError} />
         }
     } else {
         if (!currentDatasetId) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -16,8 +16,6 @@ export const getUserDetails = '/user';
 
 export const getDatasets = '/datasets'
 
-export const getWorkflows = '/workflows'
-
 export const getWorkflow = datasetId =>
     `/workflows/${datasetId}/state`
 

--- a/pages/logout.js
+++ b/pages/logout.js
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router'
 import { makeUseAxios } from 'axios-hooks'
 import { baseAxiosConfig, logoutApiRequest } from '../lib/api';
+import ErrorPagePopup from '../components/ErrorPagePopup';
 
 const useAxios = makeUseAxios(baseAxiosConfig)
 
@@ -12,7 +13,7 @@ export default function LogoutPage() {
     if (loading) {
         return 'Logging out...'
     } else if (error) {
-        return 'Logout Error'
+        return <ErrorPagePopup apiError={error} />
     } else {
         router.push('/');
         return null;


### PR DESCRIPTION
https://fjelltopp.atlassian.net/browse/NAV-144

Updates:
- Reuse `ErrorPagePopup` to handle all API errors across the app
- Handle `userDetailsError` and `datasetsError` much better
- and errors caused from logging out