### PR TITLE
NAV-149-implement-currentTask-completed-field

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -9,8 +9,7 @@ import {
     taskCompleteCheckbox,
     priorTaskButton,
     nextTaskButton,
-    whatsNextButton,
-    getWorkflowStats
+    whatsNextButton
 } from '../lib/actionButtons';
 
 const displayStatsData = (showDebugData, onClickAction) => (
@@ -25,9 +24,8 @@ const displayStatsData = (showDebugData, onClickAction) => (
 )
 
 export function TaskCompleteCheckbox({ workflow, handleClick, showDebugData }) {
-    const { complete } = getWorkflowStats(workflow);
     const buttonAppearance = (
-        complete
+        workflow.currentTask.completed
             ? {
                 label: 'Task Complete',
                 variant: 'outline-success',

--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -8,12 +8,11 @@ export const actions = {
   toggleCompleteStateLocally: 'toggleCompleteStateLocally'
 }
 
-export function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
-  const { id: currentTaskId, manual } = currentTask;
+function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
+  const { id: currentTaskId, manual, completed } = currentTask;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;
   const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;
-  const complete = !(isLatestTask || currentTask.skipped);
-  return { currentTaskId, complete, manual, isOldestTask, isLatestTask }
+  return { currentTaskId, completed, manual, isOldestTask, isLatestTask }
 }
 
 function errorCheckButton(workflowState, enabled, onClickAction) {
@@ -29,7 +28,7 @@ function errorCheckButton(workflowState, enabled, onClickAction) {
 };
 
 export function taskCompleteCheckbox(workflowState) {
-  const { complete, manual, isLatestTask } = getWorkflowStats(workflowState);
+  const { completed, manual, isLatestTask } = getWorkflowStats(workflowState);
   const enabled = (() => {
     if (isLatestTask) {
       return true;
@@ -44,14 +43,14 @@ export function taskCompleteCheckbox(workflowState) {
   const onClickAction = (() => {
     if (isLatestTask) {
       if (manual) {
-        if (complete) {
+        if (completed) {
           return actions.markTaskAsIncomplete
         } else {
           return actions.markTaskAsComplete
         }
       } else {
         if (manual) {
-          if (complete) {
+          if (completed) {
             return actions.markTaskAsIncomplete;
           } else {
             return actions.markTaskAsComplete
@@ -62,7 +61,7 @@ export function taskCompleteCheckbox(workflowState) {
       }
     } else {
       if (manual) {
-        if (complete) {
+        if (completed) {
           return actions.markTaskAsIncomplete;
         } else {
           return actions.markTaskAsComplete;
@@ -75,7 +74,7 @@ export function taskCompleteCheckbox(workflowState) {
   errorCheckButton(workflowState, enabled, onClickAction);
   return {
     enabled,
-    checked: complete,
+    checked: completed,
     onClickAction
   };
 };
@@ -129,10 +128,10 @@ export function nextTaskButton(workflowState) {
 };
 
 export function whatsNextButton(workflowState) {
-  const { complete } = getWorkflowStats(workflowState);
+  const { completed } = getWorkflowStats(workflowState);
   const enabled = true;
   const onClickAction = (() => {
-    if (complete) {
+    if (completed) {
       return actions.fetchLatestWorkflowState
     } else {
       return actions.skipTaskAndFetchLatestWorkflowState

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -10,13 +10,14 @@ const id = 'task1';
 
 describe('The "Task Complete" button should', () => {
     describe('If the task isLatestTask in the breadcrumbs', () => {
+        const completed = false;
         const enabled = true;
         const taskBreadcrumbs = ['task0', 'task1'];
         describe('and is set to manual', () => {
             const manual = true;
             test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
                 const checked = false;
-                const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -28,7 +29,7 @@ describe('The "Task Complete" button should', () => {
             const manual = false;
             test('and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action', () => {
                 const checked = false;
-                const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -43,8 +44,9 @@ describe('The "Task Complete" button should', () => {
             const enabled = true;
             const manual = true;
             test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
+                const completed = false;
                 const checked = false;
-                const workflowState = { currentTask: { id, manual, skipped: true }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -52,8 +54,9 @@ describe('The "Task Complete" button should', () => {
                     });
             });
             test('and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action', () => {
+                const completed = true;
                 const checked = true;
-                const workflowState = { currentTask: { id, manual, skipped: false }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({
                         enabled, checked,
@@ -65,14 +68,16 @@ describe('The "Task Complete" button should', () => {
             const enabled = false;
             const manual = false;
             test('and is incomplete, should return an disabled unchecked button', () => {
+                const completed = false;
                 const checked = false;
-                const workflowState = { currentTask: { id, manual, skipped: true }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({ enabled, checked, onClickAction: null });
             });
             test('and is complete, should return an disabled checked button', () => {
+                const completed = true;
                 const checked = true;
-                const workflowState = { currentTask: { id, manual, skipped: false }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
                 expect(taskCompleteCheckbox(workflowState))
                     .toStrictEqual({ enabled, checked, onClickAction: null });
             });
@@ -139,8 +144,9 @@ describe('The "Next Task" button should', () => {
 
 describe('The "What\'s Next" button should', () => {
     test('If the task is complete, should return an enabled button with the onclick [fetchLatestWorkflowState] actions', () => {
+        const completed = true;
         const taskBreadcrumbs = ['task1', 'task2'];
-        const workflowState = { currentTask: { id, skipped: false }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id, completed }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toStrictEqual({
                 enabled: true,
@@ -148,8 +154,9 @@ describe('The "What\'s Next" button should', () => {
             });
     });
     test('If the task is incomplete, should return an enabled button with the onclick skipTaskAndFetchLatestWorkflowState actions', () => {
+        const completed = false;
         const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-        const workflowState = { currentTask: { id, skipped: true }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id, completed }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toStrictEqual({
                 enabled: true,

--- a/pages/index.js
+++ b/pages/index.js
@@ -44,7 +44,7 @@ export default function Index(props) {
     const updateWorkflowComplete = (complete, postToApi) => {
       function updateLocalState() {
         let updatedWorkflow = { ...workflow };
-        updatedWorkflow.currentTask.skipped = !complete;
+        updatedWorkflow.currentTask.completed = complete;
         setWorkflow(updatedWorkflow)
       }
       if (postToApi) {
@@ -94,7 +94,7 @@ export default function Index(props) {
     } else if (actionToCarryOut === actions.fetchLatestWorkflowState) {
       fetchWorkflow();
     } else if (actionToCarryOut === actions.toggleCompleteStateLocally) {
-      updateWorkflowComplete(!workflow.currentTask.skipped, false);
+      updateWorkflowComplete(!workflow.currentTask.completed, false);
     } else {
       throw new Error([`Unknown action: ${actionToCarryOut}`])
     }


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/NAV-149
- The navigator-api has reverted back to having a `completed` field which acts the same as the old `details.complete`
- So we're reverting a lot of work done here https://github.com/fjelltopp/navigator_ui/pull/6 
- Some minor changes have been name such as renaming `details.complete` to `completed`

Test results:
```
$ yarn test
yarn run v1.22.17
$ jest
 PASS  lib/actionButtons.test.js
  The "Task Complete" button should
    If the task isLatestTask in the breadcrumbs
      and is set to manual
        ✓ and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action (4 ms)
      and is set to not manual
        ✓ and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action (1 ms)
    If the task !isLatestTask in the breadcrumbs
      and is set to manual
        ✓ and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action (1 ms)
        ✓ and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action (1 ms)
      and is set to not manual
        ✓ and is incomplete, should return an disabled unchecked button (1 ms)
        ✓ and is complete, should return an disabled checked button
  The "Prior Task" button should
    If the task is set to manual
      ✓ and if !isOldestTask in the breadcrumbs, should return an enabled button with the getPreviousTask onclick action (1 ms)
      ✓ and if isOldestTask in the breadcrumbs, should return a disabled button (1 ms)
    If the task is not set to manual
      ✓ and if breadcrumbs length > 1, should return an enabled button with the getPreviousTask onclick action (1 ms)
      ✓ and if breadcrumbs length <= 1, should return a disabled button (1 ms)
  The "Next Task" button should
    ✓ If the task isLatestTask in the breadcrumbs, should return an disabled button
    ✓ If the task !isLatestTask in the breadcrumbs, should return an enabled button with the onclick getNextTask action
  The "What's Next" button should
    ✓ If the task is complete, should return an enabled button with the onclick [fetchLatestWorkflowState] actions
    ✓ If the task is incomplete, should return an enabled button with the onclick skipTaskAndFetchLatestWorkflowState actions

Test Suites: 1 passed, 1 total
Tests:       14 passed, 14 total
Snapshots:   0 total
Time:        0.823 s, estimated 1 s
Ran all test suites.
Done in 2.44s.
```