### PR TITLE
NAV-147 only scroll in the y direction

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,5 +73,5 @@ select {
 
 #DatasetListView .list-group{
   max-height: 234px;
-  overflow: scroll;
+  overflow-y: scroll;
 }


### PR DESCRIPTION
The dataset selector has both x and y scroll bars visible for me.  We should only be scrolling in the y direction.  This is a two character change to fix the issue. 

From this...

![navigator miniku](https://user-images.githubusercontent.com/8988344/143288842-9713a69c-e2ea-4241-9995-c9f54a299ab8.png)

To this...

![navigator miniku (1)](https://user-images.githubusercontent.com/8988344/143288850-6a419fdd-af37-40bb-91c8-2e26430050d4.png)


