### PR TITLE
NAV-155-disable-buttons-if-terminus

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -6,6 +6,7 @@ import {
     faAngleDoubleRight, faCheckSquare
 } from '@fortawesome/free-solid-svg-icons';
 import {
+    getWorkflowStats,
     taskCompleteCheckbox,
     priorTaskButton,
     nextTaskButton,
@@ -24,8 +25,9 @@ const displayStatsData = (showDebugData, onClickAction) => (
 )
 
 export function TaskCompleteCheckbox({ workflow, handleClick, showDebugData }) {
+    const { completed } = getWorkflowStats(workflow);
     const buttonAppearance = (
-        workflow.currentTask.completed
+        completed
             ? {
                 label: 'Task Complete',
                 variant: 'outline-success',
@@ -55,14 +57,17 @@ export function TaskCompleteCheckbox({ workflow, handleClick, showDebugData }) {
     if (button.enabled) {
         return buttonComponent;
     } else {
-        const overlay = (
-            <Tooltip>
-                <p>Task status is automatically checked by system.</p>
-                <p>Click "What's Next" once task is complete.</p>
-            </Tooltip>
-        )
+        const { terminus } = getWorkflowStats(workflow);
+        const overlayText = terminus
+            ? <span>This workflow is now complete</span>
+            : (
+                <>
+                    <div>Task status is automatically checked by system.</div>
+                    <div>Click "What's Next" once task is complete.</div>
+                </>
+            )
         return (
-            <OverlayTrigger overlay={overlay}>
+            <OverlayTrigger overlay={<Tooltip>{overlayText}</Tooltip>}>
                 <span className="d-inline-block">
                     {buttonComponent}
                 </span>

--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -8,7 +8,7 @@ export const actions = {
   toggleCompleteStateLocally: 'toggleCompleteStateLocally'
 }
 
-function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
+export function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
   const { id: currentTaskId, manual, completed } = currentTask;
   const { terminus } = currentTask.details;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;

--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -9,8 +9,9 @@ export const actions = {
 }
 
 export function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
-  const { id: currentTaskId, manual, completed } = currentTask;
+  const { id: currentTaskId, manual} = currentTask;
   const { terminus } = currentTask.details;
+  const completed = terminus ? true : currentTask.completed;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;
   const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;
   return { currentTaskId, completed, manual, isOldestTask, isLatestTask, terminus }

--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -10,9 +10,10 @@ export const actions = {
 
 function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
   const { id: currentTaskId, manual, completed } = currentTask;
+  const { terminus } = currentTask.details;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;
   const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;
-  return { currentTaskId, completed, manual, isOldestTask, isLatestTask }
+  return { currentTaskId, completed, manual, isOldestTask, isLatestTask, terminus }
 }
 
 function errorCheckButton(workflowState, enabled, onClickAction) {
@@ -28,9 +29,11 @@ function errorCheckButton(workflowState, enabled, onClickAction) {
 };
 
 export function taskCompleteCheckbox(workflowState) {
-  const { completed, manual, isLatestTask } = getWorkflowStats(workflowState);
+  const { completed, manual, isLatestTask, terminus } = getWorkflowStats(workflowState);
   const enabled = (() => {
-    if (isLatestTask) {
+    if (terminus) {
+      return false;
+    } else if (isLatestTask) {
       return true;
     } else {
       if (manual) {
@@ -41,7 +44,9 @@ export function taskCompleteCheckbox(workflowState) {
     }
   })();;
   const onClickAction = (() => {
-    if (isLatestTask) {
+    if (terminus) {
+      return null;
+    } else if (isLatestTask) {
       if (manual) {
         if (completed) {
           return actions.markTaskAsIncomplete
@@ -108,16 +113,20 @@ export function priorTaskButton(workflowState) {
 };
 
 export function nextTaskButton(workflowState) {
-  const { isLatestTask } = getWorkflowStats(workflowState);
+  const { isLatestTask, terminus } = getWorkflowStats(workflowState);
   const enabled = (() => {
-    if (isLatestTask) {
+    if (terminus) {
+      return false;
+    } else if (isLatestTask) {
       return false;
     } else {
       return true;
     }
   })();
   const onClickAction = (() => {
-    if (isLatestTask) {
+    if (terminus) {
+      return null;
+    } else if (isLatestTask) {
       return null;
     } else {
       return actions.getNextTask;

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -9,88 +9,106 @@ import {
 const id = 'task1';
 
 describe('The "Task Complete" button should', () => {
-    describe('If the task isLatestTask in the breadcrumbs', () => {
-        const completed = false;
-        const enabled = true;
-        const taskBreadcrumbs = ['task0', 'task1'];
-        describe('and is set to manual', () => {
-            const manual = true;
-            test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
-                const checked = false;
-                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({
-                        enabled, checked,
-                        onClickAction: actions.markTaskAsComplete
-                    });
-            });
-        });
-        describe('and is set to not manual', () => {
-            const manual = false;
-            test('and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action', () => {
-                const checked = false;
-                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({
-                        enabled, checked,
-                        onClickAction: actions.toggleCompleteStateLocally
-                    });
-            });
+    describe('if the workflow is terminus', () => {
+        const details = { terminus: true };
+        test('always return a disabled button with no onClick Action', () => {
+            const completed = true;
+            const taskBreadcrumbs = ['task1'];
+            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+            expect(taskCompleteCheckbox(workflowState))
+                .toStrictEqual({
+                    enabled: false,
+                    checked: true,
+                    onClickAction: null
+                });
         });
     });
-    describe('If the task !isLatestTask in the breadcrumbs', () => {
-        const taskBreadcrumbs = ['task1', 'task2'];
-        describe('and is set to manual', () => {
+    describe('if the workflow is not terminus', () => {
+        const details = { terminus: false };
+        describe('If the task isLatestTask in the breadcrumbs', () => {
+            const completed = false;
             const enabled = true;
-            const manual = true;
-            test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
-                const completed = false;
-                const checked = false;
-                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({
-                        enabled, checked,
-                        onClickAction: actions.markTaskAsComplete
-                    });
+            const taskBreadcrumbs = ['task0', 'task1'];
+            describe('and is set to manual', () => {
+                const manual = true;
+                test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
+                    const checked = false;
+                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    expect(taskCompleteCheckbox(workflowState))
+                        .toStrictEqual({
+                            enabled, checked,
+                            onClickAction: actions.markTaskAsComplete
+                        });
+                });
             });
-            test('and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action', () => {
-                const completed = true;
-                const checked = true;
-                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({
-                        enabled, checked,
-                        onClickAction: actions.markTaskAsIncomplete
-                    });
+            describe('and is set to not manual', () => {
+                const manual = false;
+                test('and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action', () => {
+                    const checked = false;
+                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    expect(taskCompleteCheckbox(workflowState))
+                        .toStrictEqual({
+                            enabled, checked,
+                            onClickAction: actions.toggleCompleteStateLocally
+                        });
+                });
             });
         });
-        describe('and is set to not manual', () => {
-            const enabled = false;
-            const manual = false;
-            test('and is incomplete, should return an disabled unchecked button', () => {
-                const completed = false;
-                const checked = false;
-                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({ enabled, checked, onClickAction: null });
+        describe('If the task !isLatestTask in the breadcrumbs', () => {
+            const taskBreadcrumbs = ['task1', 'task2'];
+            describe('and is set to manual', () => {
+                const enabled = true;
+                const manual = true;
+                test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
+                    const completed = false;
+                    const checked = false;
+                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    expect(taskCompleteCheckbox(workflowState))
+                        .toStrictEqual({
+                            enabled, checked,
+                            onClickAction: actions.markTaskAsComplete
+                        });
+                });
+                test('and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action', () => {
+                    const completed = true;
+                    const checked = true;
+                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    expect(taskCompleteCheckbox(workflowState))
+                        .toStrictEqual({
+                            enabled, checked,
+                            onClickAction: actions.markTaskAsIncomplete
+                        });
+                });
             });
-            test('and is complete, should return an disabled checked button', () => {
-                const completed = true;
-                const checked = true;
-                const workflowState = { currentTask: { id, manual, completed }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toStrictEqual({ enabled, checked, onClickAction: null });
+            describe('and is set to not manual', () => {
+                const enabled = false;
+                const manual = false;
+                test('and is incomplete, should return an disabled unchecked button', () => {
+                    const completed = false;
+                    const checked = false;
+                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    expect(taskCompleteCheckbox(workflowState))
+                        .toStrictEqual({ enabled, checked, onClickAction: null });
+                });
+                test('and is complete, should return an disabled checked button', () => {
+                    const completed = true;
+                    const checked = true;
+                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    expect(taskCompleteCheckbox(workflowState))
+                        .toStrictEqual({ enabled, checked, onClickAction: null });
+                });
             });
         });
     });
 });
 
 describe('The "Prior Task" button should', () => {
+    const details = { terminus: false };
     describe('If the task is set to manual', () => {
         const manual = true;
         test('and if !isOldestTask in the breadcrumbs, should return an enabled button with the getPreviousTask onclick action', () => {
             const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({
                     enabled: true,
@@ -99,7 +117,7 @@ describe('The "Prior Task" button should', () => {
         });
         test('and if isOldestTask in the breadcrumbs, should return a disabled button', () => {
             const taskBreadcrumbs = ['task1', 'task2'];
-            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({ enabled: false, onClickAction: null });
         });
@@ -108,7 +126,7 @@ describe('The "Prior Task" button should', () => {
         const manual = false;
         test('and if breadcrumbs length > 1, should return an enabled button with the getPreviousTask onclick action', () => {
             const taskBreadcrumbs = ['task0', 'task1'];
-            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({
                     enabled: true,
@@ -117,7 +135,7 @@ describe('The "Prior Task" button should', () => {
         });
         test('and if breadcrumbs length <= 1, should return a disabled button', () => {
             const taskBreadcrumbs = ['task1'];
-            const workflowState = { currentTask: { id, manual }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toStrictEqual({ enabled: false, onClickAction: null });
         });
@@ -125,28 +143,42 @@ describe('The "Prior Task" button should', () => {
 });
 
 describe('The "Next Task" button should', () => {
-    test('If the task isLatestTask in the breadcrumbs, should return an disabled button', () => {
-        const taskBreadcrumbs = ['task0', 'task1'];
-        const workflowState = { currentTask: { id }, taskBreadcrumbs };
-        expect(nextTaskButton(workflowState))
-            .toStrictEqual({ enabled: false, onClickAction: null });
+    describe('if the workflow is terminus', () => {
+        const details = { terminus: true };
+        test('The "Next Task" button should be disabled', () => {
+            const completed = true;
+            const taskBreadcrumbs = ['task1', 'task2'];
+            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+            expect(nextTaskButton(workflowState))
+                .toStrictEqual({ enabled: false, onClickAction: null });
+        });
     });
-    test('If the task !isLatestTask in the breadcrumbs, should return an enabled button with the onclick getNextTask action', () => {
-        const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-        const workflowState = { currentTask: { id }, taskBreadcrumbs };
-        expect(nextTaskButton(workflowState))
-            .toStrictEqual({
-                enabled: true,
-                onClickAction: actions.getNextTask
-            });
+    describe('if the workflow is not terminus', () => {
+        const details = { terminus: false };
+        test('If the task isLatestTask in the breadcrumbs, should return an disabled button', () => {
+            const taskBreadcrumbs = ['task0', 'task1'];
+            const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
+            expect(nextTaskButton(workflowState))
+                .toStrictEqual({ enabled: false, onClickAction: null });
+        });
+        test('If the task !isLatestTask in the breadcrumbs, should return an enabled button with the onclick getNextTask action', () => {
+            const taskBreadcrumbs = ['task0', 'task1', 'task2'];
+            const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
+            expect(nextTaskButton(workflowState))
+                .toStrictEqual({
+                    enabled: true,
+                    onClickAction: actions.getNextTask
+                });
+        });
     });
 });
 
 describe('The "What\'s Next" button should', () => {
+    const details = { terminus: false };
     test('If the task is complete, should return an enabled button with the onclick [fetchLatestWorkflowState] actions', () => {
         const completed = true;
         const taskBreadcrumbs = ['task1', 'task2'];
-        const workflowState = { currentTask: { id, completed }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toStrictEqual({
                 enabled: true,
@@ -156,7 +188,7 @@ describe('The "What\'s Next" button should', () => {
     test('If the task is incomplete, should return an enabled button with the onclick skipTaskAndFetchLatestWorkflowState actions', () => {
         const completed = false;
         const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-        const workflowState = { currentTask: { id, completed }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toStrictEqual({
                 enabled: true,


### PR DESCRIPTION
https://fjelltopp.atlassian.net/browse/NAV-155
- Set `terminus` using `workflow.currentTask.details.terminus`
- If `terminus`  then disable the `taskCompleteCheckbox` and `nextTaskButton` buttons

Add a tooltip over the disabled `taskCompleteCheckbox`

![image](https://user-images.githubusercontent.com/2634482/143574938-8e0420f5-7db8-411a-becf-74f2a2bebda5.png)


## Tests output:
```
$ yarn test
yarn run v1.22.17
$ jest
 PASS  lib/actionButtons.test.js
  The "Task Complete" button should
    if the workflow is terminus
      ✓ always return a disabled button with no onClick Action (4 ms)
    if the workflow is not terminus
      If the task isLatestTask in the breadcrumbs
        and is set to manual
          ✓ and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action (1 ms)
        and is set to not manual
          ✓ and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action (1 ms)
      If the task !isLatestTask in the breadcrumbs
        and is set to manual
          ✓ and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action (1 ms)
          ✓ and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action (1 ms)
        and is set to not manual
          ✓ and is incomplete, should return an disabled unchecked button
          ✓ and is complete, should return an disabled checked button
  The "Prior Task" button should
    If the task is set to manual
      ✓ and if !isOldestTask in the breadcrumbs, should return an enabled button with the getPreviousTask onclick action (1 ms)
      ✓ and if isOldestTask in the breadcrumbs, should return a disabled button
    If the task is not set to manual
      ✓ and if breadcrumbs length > 1, should return an enabled button with the getPreviousTask onclick action
      ✓ and if breadcrumbs length <= 1, should return a disabled button (1 ms)
  The "Next Task" button should
    if the workflow is terminus
      ✓ The "Next Task" button should be disabled (1 ms)
    if the workflow is not terminus
      ✓ If the task isLatestTask in the breadcrumbs, should return an disabled button (1 ms)
      ✓ If the task !isLatestTask in the breadcrumbs, should return an enabled button with the onclick getNextTask action (1 ms)
  The "What's Next" button should
    ✓ If the task is complete, should return an enabled button with the onclick [fetchLatestWorkflowState] actions (1 ms)
    ✓ If the task is incomplete, should return an enabled button with the onclick skipTaskAndFetchLatestWorkflowState actions (1 ms)

Test Suites: 1 passed, 1 total
Tests:       16 passed, 16 total
Snapshots:   0 total
Time:        0.447 s, estimated 1 s
Ran all test suites.
Done in 2.41s.
```