### PR TITLE
NAV-151 Add Forgot password link

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+CKAN_SITE_URL=https://adr.unaids.org
 NEXT_PUBLIC_API_BASE_URL=http://navigator.minikube/api

--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-CKAN_SITE_URL=https://adr.unaids.org
+NEXT_PUBLIC_CKAN_SITE_URL=https://adr.unaids.org
 NEXT_PUBLIC_API_BASE_URL=http://navigator.minikube/api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Install dependencies only when needed
 FROM node:lts-buster-slim as builder
 WORKDIR /app
+ARG CKAN_SITE_URL=https://adr.unaids.org
 ARG NEXT_PUBLIC_API_BASE_URL=https://navigator.fjelltopp.org/api
 ARG NODE_ENV=development
 ARG NEXT_TELEMETRY_DISABLED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Install dependencies only when needed
 FROM node:lts-buster-slim as builder
 WORKDIR /app
-ARG CKAN_SITE_URL=https://adr.unaids.org
+ARG NEXT_PUBLIC_CKAN_SITE_URL=https://adr.unaids.org
 ARG NEXT_PUBLIC_API_BASE_URL=https://navigator.fjelltopp.org/api
 ARG NODE_ENV=development
 ARG NEXT_TELEMETRY_DISABLED=1

--- a/pages/login.js
+++ b/pages/login.js
@@ -62,10 +62,10 @@ export default function Login({ }) {
                 <p>
                     <span>Please login using your </span>
                     <a
-                        href="https://adr.unaids.org"
+                        href={process.env.CKAN_SITE_URL}
                         target="_blank"
                         rel="noreferrer"
-                        className="link-danger">adr.unaids.org</a>
+                        className="link-danger">{process.env.CKAN_SITE_URL}</a>
                     <span> login details:</span>
                 </p>
                 <Form.Group className="mb-3">
@@ -92,14 +92,14 @@ export default function Login({ }) {
                 <Button
                     as={'a'}
                     variant="link"
-                    href="https://adr.unaids.org/user/register"
+                    href={`${process.env.CKAN_SITE_URL}/user/register`}
                     target="_blank"
                     className="text-secondary"
                 >Register</Button>
                 <Button
                     as={'a'}
                     variant="link"
-                    href="https://adr.unaids.org/user/reset"
+                    href={`${process.env.CKAN_SITE_URL}/user/reset`}
                     target="_blank"
                     className="text-secondary float-end"
                 >Forgot password?</Button>

--- a/pages/login.js
+++ b/pages/login.js
@@ -62,10 +62,10 @@ export default function Login({ }) {
                 <p>
                     <span>Please login using your </span>
                     <a
-                        href={process.env.CKAN_SITE_URL}
+                        href={process.env.NEXT_PUBLIC_CKAN_SITE_URL}
                         target="_blank"
                         rel="noreferrer"
-                        className="link-danger">{process.env.CKAN_SITE_URL}</a>
+                        className="link-danger">{process.env.NEXT_PUBLIC_CKAN_SITE_URL}</a>
                     <span> login details:</span>
                 </p>
                 <Form.Group className="mb-3">
@@ -92,14 +92,14 @@ export default function Login({ }) {
                 <Button
                     as={'a'}
                     variant="link"
-                    href={`${process.env.CKAN_SITE_URL}/user/register`}
+                    href={`${process.env.NEXT_PUBLIC_CKAN_SITE_URL}/user/register`}
                     target="_blank"
                     className="text-secondary"
                 >Register</Button>
                 <Button
                     as={'a'}
                     variant="link"
-                    href={`${process.env.CKAN_SITE_URL}/user/reset`}
+                    href={`${process.env.NEXT_PUBLIC_CKAN_SITE_URL}/user/reset`}
                     target="_blank"
                     className="text-secondary float-end"
                 >Forgot password?</Button>

--- a/pages/login.js
+++ b/pages/login.js
@@ -58,7 +58,7 @@ export default function Login({ }) {
             <p>The HIV Estimates Navigator (“Navigator”) is the latest tool provided by UNAIDS to assist country teams to produce their annual HIV estimates. The Navigator is an automated, step-by-step assistant for estimates teams. Whether you have participated in the estimates for many years or it’s your first time, the Navigator will guide you through the process across all estimates tools and models. From generating your input data to selecting advanced options and fitting your models, Navigator provides detailed, step-by-step instructions and resources to assist you along the way. Need to step away for a bit? No problem, Navigator will help you pick up where you left off, telling you what's next and what tasks remain to be done.</p>
             <hr />
             <ErrorBanner />
-            <form id="LoginPage" onSubmit={handleSubmit}>
+            <form id="LoginForm" onSubmit={handleSubmit}>
                 <p>
                     <span>Please login using your </span>
                     <a
@@ -101,7 +101,7 @@ export default function Login({ }) {
                     variant="link"
                     href="https://adr.unaids.org/user/reset"
                     target="_blank"
-                    className="text-secondary"
+                    className="text-secondary float-end"
                 >Forgot password?</Button>
             </form>
             <hr />

--- a/pages/login.js
+++ b/pages/login.js
@@ -96,6 +96,13 @@ export default function Login({ }) {
                     target="_blank"
                     className="text-secondary"
                 >Register</Button>
+                <Button
+                    as={'a'}
+                    variant="link"
+                    href="https://adr.unaids.org/user/reset"
+                    target="_blank"
+                    className="text-secondary"
+                >Forgot password?</Button>
             </form>
             <hr />
             <Row className="text-center">


### PR DESCRIPTION
Adds a "Forgot password?" link to the login page.

At the moment this is pointing to production ADR, just as the "register" next to it, irrespective of whether Navigator backend is pointing to ADR Staging or Production.   I think this is ok, since pointing the user to ADR staging through this link is probably also somewhat confusing - there is no perfect solution.  However if someone else thinks it is an important urgently required change and has an idea how, then of course... go for it. 

![image](https://user-images.githubusercontent.com/2634482/144599791-28957491-101d-493e-83c9-013523fe7154.png)
