### PR TITLE
Reintroduce WIP label for "Task list"

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -5,7 +5,7 @@ export default function Sidebar() {
 
     const sidebarLinks = [
         { label: "What's Next?", href: '/' },
-        { label: workInProgress('Task List'), href: '/tasks' },
+        { label: 'Task List', href: '/tasks' },
         { label: 'How to use Navigator', href: 'https://hivtools.unaids.org/wp-content/uploads/G.13-How-to-use-the-ADR-Navigator.mp4' },
         { label: 'HIV Tools', href: 'https://hivtools.unaids.org' },
         { label: 'Contact Us', href: '/contact_us' },


### PR DESCRIPTION
There was a merge error.  It seem work in progress function has been removed, which is a shame since I would have preferred to keep the label there for now. 