### PR TITLE
NAV-234-remove-full-page-blocking-errors-in-index

### DIFF
--- a/components/ErrorComponents.js
+++ b/components/ErrorComponents.js
@@ -5,33 +5,22 @@ import { faArrowsRotate } from '@fortawesome/free-solid-svg-icons';
 import LogsComponent from './LogsComponent';
 import { TechnicalSupportEmailAddress } from '../pages/contact_us';
 
-function RefreshPageButton() {
-    return (
-        <Button variant="danger" onClick={() => location.reload(true)}>
-            <FontAwesomeIcon icon={faArrowsRotate} className="me-2" />
-            <span>Refresh Page</span>
-        </Button>
-    )
-}
-
-function ToggleViewErrorLogsButton({ showJsonDump, setshowJsonDump }) {
-    const handleClick = () => setshowJsonDump(!showJsonDump)
-    return (
-        <Button variant="light" onClick={handleClick}>View Error Logs</Button>
-    )
-}
-
 function BaseErrorAlert({ title, lines, error }) {
     const [showJsonDump, setshowJsonDump] = useState(false);
     return (
-        <Alert variant="danger" className="mt-3 mb-1" >
+        <Alert variant="danger">
             <Alert.Heading>{title}</Alert.Heading>
             <hr />
             {lines.map((line, index) => <div key={index}>{line}</div>)}
             <div>For technical support, contact <TechnicalSupportEmailAddress /></div>
             <ButtonGroup size="sm" className="mt-3">
-                <RefreshPageButton />
-                <ToggleViewErrorLogsButton {...{ showJsonDump, setshowJsonDump }} />
+                <Button variant="danger" onClick={() => location.reload(true)}>
+                    <FontAwesomeIcon icon={faArrowsRotate} className="me-2" />
+                    <span>Refresh Page</span>
+                </Button>
+                <Button variant="light" onClick={() => setshowJsonDump(!showJsonDump)}>
+                    <span>View Error Logs</span>
+                </Button>
             </ButtonGroup>
             {showJsonDump && (
                 <Col xs={{ span: 10, offset: 1 }}>
@@ -67,6 +56,33 @@ export function FetchMilestoneError({ error }) {
     const lines = [
         'An unexpected error occurred when trying to load this milestone,',
         'Please try refreshing this page or switching to another dataset.'
+    ];
+    return <BaseErrorAlert {...{ title, lines, error }} />
+}
+
+export function MarkTaskAsCompleteError({ error }) {
+    const title = `Failed to complete task`;
+    const lines = [
+        'An unexpected error occurred when trying to mark this task as complete,',
+        'Please try completing the action again or refreshing this page.'
+    ];
+    return <BaseErrorAlert {...{ title, lines, error }} />
+}
+
+export function MarkTaskAsIncompleteError({ error }) {
+    const title = `Failed to mark task as incomplete`;
+    const lines = [
+        'An unexpected error occurred when trying to mark this task as incomplete,',
+        'Please try completing the action again or refreshing this page.'
+    ];
+    return <BaseErrorAlert {...{ title, lines, error }} />
+}
+
+export function SkipTaskError({ error }) {
+    const title = `Failed to skip task`;
+    const lines = [
+        'An unexpected error occurred when trying to skip this task,',
+        'Please try completing the action again or refreshing this page.'
     ];
     return <BaseErrorAlert {...{ title, lines, error }} />
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,8 +36,8 @@ export default function IndexPage(props) {
   const [workflow, setWorkflow] = useState();
   const [_loading, setLoading] = useState(false);
   const [actionError, _setActionError] = useState(null);
-  function setActionError(action, error) {
-    _setActionError({ action, error });
+  function setActionError(name, error) {
+    _setActionError({ name, error });
   }
 
   const [
@@ -150,10 +150,10 @@ export default function IndexPage(props) {
         ))
           .then(() => updateLocalState())
           .catch(error => {
-            const actionName = complete
-              ? 'markTaskAsComplete'
-              : 'markTaskAsIncomplete'
-            setActionError(actionName, error)
+            const errorName = complete
+              ? 'MarkTaskAsCompleteError'
+              : 'MarkTaskAsIncompleteError'
+            setActionError(errorName, error)
           })
       } else {
         updateLocalState();
@@ -179,7 +179,7 @@ export default function IndexPage(props) {
         workflow.currentTask.id
       ))
         .then(() => fetchWorkflow())
-        .catch(error => setActionError('skipTask', error))
+        .catch(error => setActionError('SkipTaskError', error))
     } else if (actionToCarryOut === actions.fetchLatestWorkflowState) {
       fetchWorkflow();
     } else if (actionToCarryOut === actions.toggleCompleteStateLocally) {
@@ -329,30 +329,30 @@ export default function IndexPage(props) {
 
   function TaskDetailsError() {
     if (actionError) {
-      switch (actionError.action) {
-        case 'markTaskAsComplete':
+      switch (actionError.name) {
+        case 'MarkTaskAsCompleteError':
           return (
             <MarkTaskAsCompleteError
               error={{
-                title: 'MarkTaskAsCompleteError',
+                title: actionError.name,
                 data: actionError.error
               }}
             />
           )
-        case 'markTaskAsIncomplete':
+        case 'MarkTaskAsIncompleteError':
           return (
             <MarkTaskAsIncompleteError
               error={{
-                title: 'MarkTaskAsIncompleteError',
+                title: actionError.name,
                 data: actionError.error
               }}
             />
           )
-        case 'skipTask':
+        case 'SkipTaskError':
           return (
             <SkipTaskError
               error={{
-                title: 'SkipTaskError',
+                title: actionError.name,
                 data: actionError.error
               }}
             />
@@ -360,7 +360,7 @@ export default function IndexPage(props) {
         case null:
           return null;
         default:
-          return `actionError.action ${actionError.action} unhandled`
+          return `actionError.name ${actionError.name} unhandled`;
       }
     } else {
       return null;

--- a/pages/index.js
+++ b/pages/index.js
@@ -101,6 +101,7 @@ export default function IndexPage(props) {
   }
   function updateWorkflowTaskFromMilestoneId(milestoneId) {
     setLoading(true);
+    setActionError(null);
     _fetchMilestone(
       getMilestone(
         props.currentDatasetId,
@@ -120,11 +121,13 @@ export default function IndexPage(props) {
 
   useEffect(() => {
     fetchWorkflow();
+    setActionError(null);
   }, [props.currentDatasetId]);
 
   useEffect(() => {
     if (workflow && redirectToTaskId) {
       updateWorkflowTask(redirectToTaskId);
+      setActionError(null);
       router.push('/', undefined, { shallow: true });
     }
   }, [workflow]);


### PR DESCRIPTION
https://fjelltopp.atlassian.net/browse/NAV-234

## Workflow and task errors
- API errors from  `fetchWorkflow, fetchWorkflowTask and fetchMilestone` will block the entire task
- The sidebar and dataset selector are still functional 

![image](https://user-images.githubusercontent.com/2634482/146368737-9eb3a3fe-b3bf-49d3-8406-2d44f50fd077.png)

## Task action errors
- API errors from `markTaskAsComplete, markTaskAsIncomplete & skipTask` will not block anything
- The UI will display red alert message at the top of the task
- All elements can still be interacted with and once clicked on, the red banner will reset

![image](https://user-images.githubusercontent.com/2634482/146369093-dbe9806e-d07c-4308-9ed4-439a77a37102.png)
