### PR TITLE
NAV-229-new-skip-logic

### DIFF
--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -4,6 +4,8 @@ export const actions = {
   getPreviousTask: 'getPreviousTask',
   getNextTask: 'getNextTask',
   skipTaskAndFetchLatestWorkflowState: 'skipTaskAndFetchLatestWorkflowState',
+  skipTaskAndGetNextTask: 'skipTaskAndGetNextTask',
+  skipTaskAndGetPreviousTask: 'skipTaskAndGetPreviousTask',
   fetchLatestWorkflowState: 'fetchLatestWorkflowState',
   toggleCompleteStateLocally: 'toggleCompleteStateLocally'
 }
@@ -17,7 +19,7 @@ export function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
   return { currentTaskId, completed, manual, isOldestTask, isLatestTask, terminus }
 }
 
-function validateButton(workflowState, enabled, onClickAction) {
+function validateButton(workflowState, enabled, tooltip, onClickAction) {
   if (enabled && !onClickAction) {
     console.error(
       'An enabled button must return one or more onClickAction.',
@@ -25,6 +27,15 @@ function validateButton(workflowState, enabled, onClickAction) {
     );
     throw new Error([
       'Enabled button returned no onClickAction. See console for logs.'
+    ]);
+  };
+  if (!enabled && !tooltip) {
+    console.error(
+      'A disabled button must have a tooltip value.',
+      `workflowState: ${JSON.stringify(workflowState)}`
+    );
+    throw new Error([
+      'Disabled button returned no tooltip. See console for logs.'
     ]);
   };
 };
@@ -89,7 +100,7 @@ export function taskCompleteCheckbox(workflowState) {
       }
     }
   })();
-  validateButton(workflowState, enabled, onClickAction);
+  validateButton(workflowState, enabled, tooltip, onClickAction);
   return {
     enabled, tooltip, onClickAction,
     checked: completed
@@ -97,36 +108,38 @@ export function taskCompleteCheckbox(workflowState) {
 };
 
 export function priorTaskButton(workflowState) {
-  const { manual, isOldestTask } = getWorkflowStats(workflowState);
+  const { completed, isOldestTask, isLatestTask } = getWorkflowStats(workflowState);
   const { enabled, tooltip } = (() => {
-    const firstTaskTooltip = ['This is your first task.'];
-    if (manual) {
-      if (!isOldestTask) {
-        return { enabled: true };
-      } else {
-        return { enabled: false, tooltip: firstTaskTooltip };
+    if (isOldestTask) {
+      return {
+        enabled: false,
+        tooltip: ['This is your first task.']
       }
     } else {
-      if (workflowState.taskBreadcrumbs.length > 1) {
-        return { enabled: true };
-      } else {
-        return { enabled: false, tooltip: firstTaskTooltip };
-      }
+      return { enabled: true }
     }
   })();
   const onClickAction = (() => {
-    if (enabled) {
-      return actions.getPreviousTask;
+    if (isOldestTask) {
+      return null
     } else {
-      return null;
-    };
+      if (isLatestTask) {
+        return actions.getPreviousTask
+      } else {
+        if (completed) {
+          return actions.getPreviousTask
+        } else {
+          return actions.skipTaskAndGetPreviousTask
+        }
+      }
+    }
   })();
-  validateButton(workflowState, enabled, onClickAction);
+  validateButton(workflowState, enabled, tooltip, onClickAction);
   return { enabled, tooltip, onClickAction };
 };
 
 export function nextTaskButton(workflowState) {
-  const { isLatestTask, terminus } = getWorkflowStats(workflowState);
+  const { isLatestTask, terminus, completed } = getWorkflowStats(workflowState);
   const { enabled, tooltip } = (() => {
     if (terminus) {
       return {
@@ -146,21 +159,22 @@ export function nextTaskButton(workflowState) {
     }
   })();
   const onClickAction = (() => {
-    if (terminus) {
-      return null;
-    } else if (isLatestTask) {
-      return null;
-    } else {
-      return actions.getNextTask;
-    };
+    if (enabled) {
+      if (completed) {
+        return actions.getNextTask;
+      } else {
+        return actions.skipTaskAndGetNextTask;
+      }
+    }
   })();
-  validateButton(workflowState, enabled, onClickAction);
+  validateButton(workflowState, enabled, tooltip, onClickAction);
   return { enabled, tooltip, onClickAction };
 };
 
 export function whatsNextButton(workflowState) {
   const { completed } = getWorkflowStats(workflowState);
   const enabled = true;
+  const tooltip = null;
   const onClickAction = (() => {
     if (completed) {
       return actions.fetchLatestWorkflowState
@@ -168,6 +182,6 @@ export function whatsNextButton(workflowState) {
       return actions.skipTaskAndFetchLatestWorkflowState
     };
   })();
-  validateButton(workflowState, enabled, onClickAction);
+  validateButton(workflowState, enabled, tooltip, onClickAction);
   return { enabled, onClickAction };
 };

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -133,15 +133,10 @@ describe('The "Prior Task" button should', () => {
         describe('if the workflow is terminus', () => {
             const details = { reached, terminus: true };
             test('always return a disabled button with no onClick Action', () => {
-                const completed = true;
                 const taskBreadcrumbs = ['task1'];
-                const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
-                expect(taskCompleteCheckbox(workflowState))
-                    .toMatchObject({
-                        enabled: false,
-                        checked: true,
-                        onClickAction: null
-                    });
+                const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+                expect(priorTaskButton(workflowState))
+                    .toMatchObject({ enabled: false });
             });
         });
         describe('if the workflow is reached and !terminus', () => {

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -118,20 +118,9 @@ describe('The "Task Complete" button should', () => {
 
 describe('The "Prior Task" button should', () => {
     const manual = true;
-    describe('if the task is !reached', () => {
-        const details = { reached: false, terminus: false };
-        test('always return a disabled button with no onClick Action', () => {
-            const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-            const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
-            expect(priorTaskButton(workflowState))
-                .toMatchObject({
-                    enabled: false,
-                    onClickAction: null
-                });
-        });
-    });
+    const reached = true;
     describe('if the workflow is terminus', () => {
-        const details = { reached: true, terminus: true };
+        const details = { reached, terminus: true };
         test('always return a disabled button with no onClick Action', () => {
             const completed = true;
             const taskBreadcrumbs = ['task1'];
@@ -145,7 +134,7 @@ describe('The "Prior Task" button should', () => {
         });
     });
     describe('if the workflow is reached and !terminus', () => {
-        const details = { reached: true, terminus: false };
+        const details = { reached, terminus: false };
         test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
             const taskBreadcrumbs = ['task1', 'task2'];
             const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -39,7 +39,7 @@ describe('The "Task Complete" button should', () => {
     });
     describe('if the workflow is reached and !terminus', () => {
         const details = { reached: true, terminus: false };
-        describe('If the task isLatestTask in the breadcrumbs', () => {
+        describe('if the task isLatestTask in the breadcrumbs', () => {
             const completed = false;
             const enabled = true;
             const taskBreadcrumbs = ['task0', 'task1'];
@@ -68,7 +68,7 @@ describe('The "Task Complete" button should', () => {
                 });
             });
         });
-        describe('If the task !isLatestTask in the breadcrumbs', () => {
+        describe('if the task !isLatestTask in the breadcrumbs', () => {
             const taskBreadcrumbs = ['task1', 'task2'];
             describe('and is set to manual', () => {
                 const enabled = true;
@@ -118,7 +118,7 @@ describe('The "Task Complete" button should', () => {
 
 describe('The "Prior Task" button should', () => {
     const manual = true;
-    describe('If the task is !reached', () => {
+    describe('if the task is !reached', () => {
         const details = { reached: false, terminus: false };
         test('always return a disabled button with no onClick Action', () => {
             const taskBreadcrumbs = ['task0', 'task1', 'task2'];
@@ -152,7 +152,7 @@ describe('The "Prior Task" button should', () => {
             expect(priorTaskButton(workflowState))
                 .toMatchObject({ enabled: false });
         })
-        describe('If !isOldestTask in the breadcrumbs', () => {
+        describe('if !isOldestTask in the breadcrumbs', () => {
             test('and if isLatestTask in the breadcrumbs, should return a button with getPreviousTask onclick action', () => {
                 const taskBreadcrumbs = ['task0', 'task1'];
                 const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
@@ -181,7 +181,7 @@ describe('The "Prior Task" button should', () => {
 describe('The "Next Task" button should', () => {
     describe('if the workflow is !reached', () => {
         const details = { reached: false, terminus: false };
-        test('The "Next Task" button should be disabled', () => {
+        test('the "Next Task" button should be disabled', () => {
             const completed = true;
             const taskBreadcrumbs = ['task1', 'task2'];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
@@ -189,7 +189,7 @@ describe('The "Next Task" button should', () => {
                 .toMatchObject({ enabled: false, onClickAction: null });
         });
     });
-    describe('If the task is reached', () => {
+    describe('if the task is reached', () => {
         const reached = true;
         test('if the workflow is terminus, should return a disabled button', () => {
             const details = { reached, terminus: true };

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -118,53 +118,65 @@ describe('The "Task Complete" button should', () => {
 
 describe('The "Prior Task" button should', () => {
     const manual = true;
-    const reached = true;
-    describe('if the workflow is terminus', () => {
-        const details = { reached, terminus: true };
-        test('always return a disabled button with no onClick Action', () => {
+    describe('if the workflow is !reached', () => {
+        const details = { reached: false, terminus: false };
+        test('the "Prior Task" button should be disabled', () => {
             const completed = true;
-            const taskBreadcrumbs = ['task1'];
+            const taskBreadcrumbs = ['task1', 'task2'];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
-            expect(taskCompleteCheckbox(workflowState))
-                .toMatchObject({
-                    enabled: false,
-                    checked: true,
-                    onClickAction: null
-                });
+            expect(priorTaskButton(workflowState))
+                .toMatchObject({ enabled: false, onClickAction: null });
         });
     });
-    describe('if the workflow is reached and !terminus', () => {
-        const details = { reached, terminus: false };
-        test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
-            const taskBreadcrumbs = ['task1', 'task2'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
-            expect(priorTaskButton(workflowState))
-                .toMatchObject({ enabled: false });
-        })
-        describe('if !isOldestTask in the breadcrumbs', () => {
-            test('and if isLatestTask in the breadcrumbs, should return a button with getPreviousTask onclick action', () => {
-                const taskBreadcrumbs = ['task0', 'task1'];
+    describe('if the task is reached', () => {
+        const reached = true;
+        describe('if the workflow is terminus', () => {
+            const details = { reached, terminus: true };
+            test('always return a disabled button with no onClick Action', () => {
+                const completed = true;
+                const taskBreadcrumbs = ['task1'];
+                const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+                expect(taskCompleteCheckbox(workflowState))
+                    .toMatchObject({
+                        enabled: false,
+                        checked: true,
+                        onClickAction: null
+                    });
+            });
+        });
+        describe('if the workflow is reached and !terminus', () => {
+            const details = { reached, terminus: false };
+            test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
+                const taskBreadcrumbs = ['task1', 'task2'];
                 const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
                 expect(priorTaskButton(workflowState))
-                    .toMatchObject({ onClickAction: actions.getPreviousTask });
+                    .toMatchObject({ enabled: false });
             })
-            describe('and if !isLatestTask in the breadcrumbs', () => {
-                const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-                test('and if task is complete should return a button with onclick getPreviousTask action', () => {
-                    const completed = true;
-                    const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+            describe('if !isOldestTask in the breadcrumbs', () => {
+                test('and if isLatestTask in the breadcrumbs, should return a button with getPreviousTask onclick action', () => {
+                    const taskBreadcrumbs = ['task0', 'task1'];
+                    const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
                     expect(priorTaskButton(workflowState))
                         .toMatchObject({ onClickAction: actions.getPreviousTask });
                 })
-                test('and if task is incomplete should return a button with onclick skipTaskAndGetPreviousTask action', () => {
-                    const completed = false;
-                    const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
-                    expect(priorTaskButton(workflowState))
-                        .toMatchObject({ onClickAction: actions.skipTaskAndGetPreviousTask });
+                describe('and if !isLatestTask in the breadcrumbs', () => {
+                    const taskBreadcrumbs = ['task0', 'task1', 'task2'];
+                    test('and if task is complete should return a button with onclick getPreviousTask action', () => {
+                        const completed = true;
+                        const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+                        expect(priorTaskButton(workflowState))
+                            .toMatchObject({ onClickAction: actions.getPreviousTask });
+                    })
+                    test('and if task is incomplete should return a button with onclick skipTaskAndGetPreviousTask action', () => {
+                        const completed = false;
+                        const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+                        expect(priorTaskButton(workflowState))
+                            .toMatchObject({ onClickAction: actions.skipTaskAndGetPreviousTask });
+                    })
                 })
             })
         })
-    })
+    });
 });
 
 describe('The "Next Task" button should', () => {

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -139,7 +139,7 @@ describe('The "Prior Task" button should', () => {
                     .toMatchObject({ enabled: false });
             });
         });
-        describe('if the workflow is reached and !terminus', () => {
+        describe('if the workflow is !terminus', () => {
             const details = { reached, terminus: false };
             test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
                 const taskBreadcrumbs = [id, 'task2'];

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -13,7 +13,7 @@ describe('The "Task Complete" button should', () => {
         const details = { reached: false, terminus: false };
         test('always return a disabled button with no onClick Action', () => {
             const completed = true;
-            const taskBreadcrumbs = ['task1'];
+            const taskBreadcrumbs = [id];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
             expect(taskCompleteCheckbox(workflowState))
                 .toMatchObject({
@@ -27,7 +27,7 @@ describe('The "Task Complete" button should', () => {
         const details = { reached: true, terminus: true };
         test('always return a disabled button with no onClick Action', () => {
             const completed = true;
-            const taskBreadcrumbs = ['task1'];
+            const taskBreadcrumbs = [id];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
             expect(taskCompleteCheckbox(workflowState))
                 .toMatchObject({
@@ -69,7 +69,7 @@ describe('The "Task Complete" button should', () => {
             });
         });
         describe('if the task !isLatestTask in the breadcrumbs', () => {
-            const taskBreadcrumbs = ['task1', 'task2'];
+            const taskBreadcrumbs = [id, 'task2'];
             describe('and is set to manual', () => {
                 const enabled = true;
                 const manual = true;
@@ -122,7 +122,7 @@ describe('The "Prior Task" button should', () => {
         const details = { reached: false, terminus: false };
         test('the "Prior Task" button should be disabled', () => {
             const completed = true;
-            const taskBreadcrumbs = ['task1', 'task2'];
+            const taskBreadcrumbs = [id, 'task2'];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
                 .toMatchObject({ enabled: false, onClickAction: null });
@@ -133,7 +133,7 @@ describe('The "Prior Task" button should', () => {
         describe('if the workflow is terminus', () => {
             const details = { reached, terminus: true };
             test('always return a disabled button with no onClick Action', () => {
-                const taskBreadcrumbs = ['task1'];
+                const taskBreadcrumbs = [id];
                 const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
                 expect(priorTaskButton(workflowState))
                     .toMatchObject({ enabled: false });
@@ -142,7 +142,7 @@ describe('The "Prior Task" button should', () => {
         describe('if the workflow is reached and !terminus', () => {
             const details = { reached, terminus: false };
             test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
-                const taskBreadcrumbs = ['task1', 'task2'];
+                const taskBreadcrumbs = [id, 'task2'];
                 const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
                 expect(priorTaskButton(workflowState))
                     .toMatchObject({ enabled: false });
@@ -155,7 +155,7 @@ describe('The "Prior Task" button should', () => {
                         .toMatchObject({ onClickAction: actions.getPreviousTask });
                 })
                 describe('and if !isLatestTask in the breadcrumbs', () => {
-                    const taskBreadcrumbs = ['task0', 'task1', 'task2'];
+                    const taskBreadcrumbs = ['task0', id, 'task2'];
                     test('and if task is complete should return a button with onclick getPreviousTask action', () => {
                         const completed = true;
                         const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
@@ -179,7 +179,7 @@ describe('The "Next Task" button should', () => {
         const details = { reached: false, terminus: false };
         test('the "Next Task" button should be disabled', () => {
             const completed = true;
-            const taskBreadcrumbs = ['task1', 'task2'];
+            const taskBreadcrumbs = [id, 'task2'];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
             expect(nextTaskButton(workflowState))
                 .toMatchObject({ enabled: false, onClickAction: null });
@@ -190,7 +190,7 @@ describe('The "Next Task" button should', () => {
         test('if the workflow is terminus, should return a disabled button', () => {
             const details = { reached, terminus: true };
             const completed = false; // value not important
-            const taskBreadcrumbs = ['task1', 'task2'];
+            const taskBreadcrumbs = [id, 'task2'];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
             expect(nextTaskButton(workflowState))
                 .toMatchObject({ enabled: false });
@@ -199,13 +199,13 @@ describe('The "Next Task" button should', () => {
             const details = { reached, terminus: false };
             test('and if isLatestTask in the breadcrumbs, should return a disabled button', () => {
                 const completed = false; // value not important
-                const taskBreadcrumbs = ['task1'];
+                const taskBreadcrumbs = [id];
                 const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
                 expect(nextTaskButton(workflowState))
                     .toMatchObject({ enabled: false });
             })
             describe('and if !isLatestTask in the breadcrumbs', () => {
-                const taskBreadcrumbs = ['task1', 'task2'];
+                const taskBreadcrumbs = [id, 'task2'];
                 test('and if the task is complete, should return a button with onclick getNextTask action', () => {
                     const completed = true;
                     const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
@@ -227,7 +227,7 @@ describe('The "What\'s Next" button should', () => {
     const details = { terminus: false };
     test('if the task is complete, should return a button with onclick fetchLatestWorkflowState actions', () => {
         const completed = true;
-        const taskBreadcrumbs = ['task1', 'task2'];
+        const taskBreadcrumbs = [id, 'task2'];
         const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toMatchObject({
@@ -237,7 +237,7 @@ describe('The "What\'s Next" button should', () => {
     });
     test('if the task is incomplete, should return a button with onclick skipTaskAndFetchLatestWorkflowState actions', () => {
         const completed = false;
-        const taskBreadcrumbs = ['task0', 'task1', 'task2'];
+        const taskBreadcrumbs = ['task0', id, 'task2'];
         const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toMatchObject({

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -88,14 +88,14 @@ describe('The "Task Complete" button should', () => {
                     const checked = false;
                     const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
-                        .toMatchObject({ enabled, checked, onClickAction: null });
+                        .toMatchObject({ enabled, checked });
                 });
                 test('and is complete, should return an disabled checked button', () => {
                     const completed = true;
                     const checked = true;
                     const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
-                        .toMatchObject({ enabled, checked, onClickAction: null });
+                        .toMatchObject({ enabled, checked });
                 });
             });
         });
@@ -104,78 +104,77 @@ describe('The "Task Complete" button should', () => {
 
 describe('The "Prior Task" button should', () => {
     const details = { terminus: false };
-    describe('If the task is set to manual', () => {
-        const manual = true;
-        test('and if !isOldestTask in the breadcrumbs, should return an enabled button with the getPreviousTask onclick action', () => {
-            const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
-            expect(priorTaskButton(workflowState))
-                .toMatchObject({
-                    enabled: true,
-                    onClickAction: actions.getPreviousTask
-                });
-        });
-        test('and if isOldestTask in the breadcrumbs, should return a disabled button', () => {
-            const taskBreadcrumbs = ['task1', 'task2'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
-            expect(priorTaskButton(workflowState))
-                .toMatchObject({ enabled: false, onClickAction: null });
-        });
-    });
-    describe('If the task is not set to manual', () => {
-        const manual = false;
-        test('and if breadcrumbs length > 1, should return an enabled button with the getPreviousTask onclick action', () => {
+    const manual = true; // TODO: confirm we no longer care if a task is manual or not
+    test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
+        const taskBreadcrumbs = ['task1', 'task2'];
+        const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+        expect(priorTaskButton(workflowState))
+            .toMatchObject({ enabled: false });
+    })
+    describe('If !isOldestTask in the breadcrumbs', () => {
+        test('and if isLatestTask in the breadcrumbs, should return a button with getPreviousTask onclick action', () => {
             const taskBreadcrumbs = ['task0', 'task1'];
             const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
             expect(priorTaskButton(workflowState))
-                .toMatchObject({
-                    enabled: true,
-                    onClickAction: actions.getPreviousTask
-                });
-        });
-        test('and if breadcrumbs length <= 1, should return a disabled button', () => {
-            const taskBreadcrumbs = ['task1'];
-            const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
-            expect(priorTaskButton(workflowState))
-                .toMatchObject({ enabled: false, onClickAction: null });
-        });
-    });
+                .toMatchObject({ onClickAction: actions.getPreviousTask });
+        })
+        describe('and if !isLatestTask in the breadcrumbs', () => {
+            const taskBreadcrumbs = ['task0', 'task1', 'task2'];
+            test('and if task is complete should return a button with onclick getPreviousTask action', () => {
+                const completed = true;
+                const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+                expect(priorTaskButton(workflowState))
+                    .toMatchObject({ onClickAction: actions.getPreviousTask });
+            })
+            test('and if task is incomplete should return a button with onclick skipTaskAndGetPreviousTask action', () => {
+                const completed = false;
+                const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+                expect(priorTaskButton(workflowState))
+                    .toMatchObject({ onClickAction: actions.skipTaskAndGetPreviousTask });
+            })
+        })
+    })
 });
 
 describe('The "Next Task" button should', () => {
-    describe('if the workflow is terminus', () => {
+    test('if the workflow is terminus, should return a disabled button', () => {
         const details = { terminus: true };
-        test('The "Next Task" button should be disabled', () => {
-            const completed = true;
-            const taskBreadcrumbs = ['task1', 'task2'];
+        const completed = false; // value not important
+        const taskBreadcrumbs = ['task1', 'task2'];
+        const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+        expect(nextTaskButton(workflowState))
+            .toMatchObject({ enabled: false });
+    });
+    describe('if the workflow is !terminus', () => {
+        const details = { terminus: false };
+        test('and if isLatestTask in the breadcrumbs, should return a disabled button', () => {
+            const completed = false; // value not important
+            const taskBreadcrumbs = ['task1'];
             const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
             expect(nextTaskButton(workflowState))
-                .toMatchObject({ enabled: false, onClickAction: null });
-        });
-    });
-    describe('if the workflow is not terminus', () => {
-        const details = { terminus: false };
-        test('If the task isLatestTask in the breadcrumbs, should return an disabled button', () => {
-            const taskBreadcrumbs = ['task0', 'task1'];
-            const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
-            expect(nextTaskButton(workflowState))
-                .toMatchObject({ enabled: false, onClickAction: null });
-        });
-        test('If the task !isLatestTask in the breadcrumbs, should return an enabled button with the onclick getNextTask action', () => {
-            const taskBreadcrumbs = ['task0', 'task1', 'task2'];
-            const workflowState = { currentTask: { id, details }, taskBreadcrumbs };
-            expect(nextTaskButton(workflowState))
-                .toMatchObject({
-                    enabled: true,
-                    onClickAction: actions.getNextTask
-                });
-        });
+                .toMatchObject({ enabled: false });
+        })
+        describe('and if !isLatestTask in the breadcrumbs', () => {
+            const taskBreadcrumbs = ['task1', 'task2'];
+            test('and if the task is complete, should return a button with onclick getNextTask action', () => {
+                const completed = true;
+                const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+                expect(nextTaskButton(workflowState))
+                    .toMatchObject({ onClickAction: actions.getNextTask });
+            })
+            test('and if the task is incomplete, should return a button with onclick skipTaskAndGetNextTask action', () => {
+                const completed = false;
+                const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+                expect(nextTaskButton(workflowState))
+                    .toMatchObject({ onClickAction: actions.skipTaskAndGetNextTask });
+            })
+        })
     });
 });
 
 describe('The "What\'s Next" button should', () => {
     const details = { terminus: false };
-    test('If the task is complete, should return an enabled button with the onclick [fetchLatestWorkflowState] actions', () => {
+    test('if the task is complete, should return a button with onclick fetchLatestWorkflowState actions', () => {
         const completed = true;
         const taskBreadcrumbs = ['task1', 'task2'];
         const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
@@ -185,7 +184,7 @@ describe('The "What\'s Next" button should', () => {
                 onClickAction: actions.fetchLatestWorkflowState
             });
     });
-    test('If the task is incomplete, should return an enabled button with the onclick skipTaskAndFetchLatestWorkflowState actions', () => {
+    test('if the task is incomplete, should return a button with onclick skipTaskAndFetchLatestWorkflowState actions', () => {
         const completed = false;
         const taskBreadcrumbs = ['task0', 'task1', 'task2'];
         const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -104,7 +104,7 @@ describe('The "Task Complete" button should', () => {
 
 describe('The "Prior Task" button should', () => {
     const details = { terminus: false };
-    const manual = true; // TODO: confirm we no longer care if a task is manual or not
+    const manual = true;
     test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
         const taskBreadcrumbs = ['task1', 'task2'];
         const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };

--- a/pages/index.js
+++ b/pages/index.js
@@ -161,6 +161,14 @@ export default function IndexPage(props) {
         updateLocalState();
       }
     }
+    const getPreviousOrNextTask = actionToCarryOut => {
+      const taskBreadcrumbs = workflow.taskBreadcrumbs;
+      const indexOfCurrentTask = taskBreadcrumbs.indexOf(workflow.currentTask.id);
+      const newTaskId = actionToCarryOut === actions.getPreviousTask
+        ? taskBreadcrumbs[indexOfCurrentTask - 1]
+        : taskBreadcrumbs[indexOfCurrentTask + 1]
+      return newTaskId;
+    }
     if (actionToCarryOut === actions.markTaskAsComplete) {
       updateWorkflowComplete(true, true);
     } else if (actionToCarryOut === actions.markTaskAsIncomplete) {
@@ -169,11 +177,7 @@ export default function IndexPage(props) {
       actions.getPreviousTask,
       actions.getNextTask
     ].includes(actionToCarryOut)) {
-      const taskBreadcrumbs = workflow.taskBreadcrumbs;
-      const indexOfCurrentTask = taskBreadcrumbs.indexOf(workflow.currentTask.id);
-      const newTaskId = actionToCarryOut === actions.getPreviousTask
-        ? taskBreadcrumbs[indexOfCurrentTask - 1]
-        : taskBreadcrumbs[indexOfCurrentTask + 1]
+      const newTaskId = getPreviousOrNextTask(actionToCarryOut);
       updateWorkflowTask(newTaskId);
     } else if (actionToCarryOut === actions.skipTaskAndFetchLatestWorkflowState) {
       _skipTask(taskSkipRequest(
@@ -181,6 +185,26 @@ export default function IndexPage(props) {
         workflow.currentTask.id
       ))
         .then(() => fetchWorkflow())
+        .catch(error => setActionError('SkipTaskError', error))
+    } else if (actionToCarryOut === actions.skipTaskAndGetNextTask) {
+      _skipTask(taskSkipRequest(
+        props.currentDatasetId,
+        workflow.currentTask.id
+      ))
+        .then(() => {
+          const newTaskId = getPreviousOrNextTask(actions.getNextTask);
+          updateWorkflowTask(newTaskId);
+        })
+        .catch(error => setActionError('SkipTaskError', error))
+    } else if (actionToCarryOut === actions.skipTaskAndGetPreviousTask) {
+      _skipTask(taskSkipRequest(
+        props.currentDatasetId,
+        workflow.currentTask.id
+      ))
+        .then(() => {
+          const newTaskId = getPreviousOrNextTask(actions.getPreviousTask);
+          updateWorkflowTask(newTaskId);
+        })
         .catch(error => setActionError('SkipTaskError', error))
     } else if (actionToCarryOut === actions.fetchLatestWorkflowState) {
       fetchWorkflow();


### PR DESCRIPTION
https://fjelltopp.atlassian.net/browse/NAV-229

# Tests
```
$ yarn test lib/actionButtons.test.js

 PASS  lib/actionButtons.test.js
  The "Task Complete" button should
    if the workflow is !reached
      ✓ always return a disabled button with no onClick Action (3 ms)
    if the workflow is terminus
      ✓ always return a disabled button with no onClick Action
    if the workflow is reached and !terminus
      if the task isLatestTask in the breadcrumbs
        and is set to manual
          ✓ and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action (1 ms)
        and is set to not manual
          ✓ and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action (1 ms)
      if the task !isLatestTask in the breadcrumbs
        and is set to manual
          ✓ and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action
          ✓ and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action
        and is set to not manual
          ✓ and is incomplete, should return an disabled unchecked button
          ✓ and is complete, should return an disabled checked button
  The "Prior Task" button should
    if the workflow is !reached
      ✓ the "Prior Task" button should be disabled (1 ms)
    if the task is reached
      if the workflow is terminus
        ✓ always return a disabled button with no onClick Action
      if the workflow is !terminus
        ✓ if isOldestTask in the breadcrumbs, should return a disabled button
        if !isOldestTask in the breadcrumbs
          ✓ and if isLatestTask in the breadcrumbs, should return a button with getPreviousTask onclick action
          and if !isLatestTask in the breadcrumbs
            ✓ and if task is complete should return a button with onclick getPreviousTask action (6 ms)
            ✓ and if task is incomplete should return a button with onclick skipTaskAndGetPreviousTask action
  The "Next Task" button should
    if the workflow is !reached
      ✓ the "Next Task" button should be disabled
    if the task is reached
      ✓ if the workflow is terminus, should return a disabled button
      if the workflow is !terminus
        ✓ and if isLatestTask in the breadcrumbs, should return a disabled button (1 ms)
        and if !isLatestTask in the breadcrumbs
          ✓ and if the task is complete, should return a button with onclick getNextTask action (1 ms)
          ✓ and if the task is incomplete, should return a button with onclick skipTaskAndGetNextTask action
  The "What's Next" button should
    ✓ if the task is complete, should return a button with onclick fetchLatestWorkflowState actions (1 ms)
    ✓ if the task is incomplete, should return a button with onclick skipTaskAndFetchLatestWorkflowState actions (1 ms)

Test Suites: 1 passed, 1 total
Tests:       21 passed, 21 total
Snapshots:   0 total
Time:        2.049 s
Ran all test suites matching /lib\/actionButtons.test.js/i.
Done in 3.51s.
```