### PR TITLE
NAV-255-fixed-reached-field-location

### DIFF
--- a/lib/actionButtons.js
+++ b/lib/actionButtons.js
@@ -16,15 +16,23 @@ const taskNotReachedTooltip = [
 ];
 
 export function getWorkflowStats({ currentTask, taskBreadcrumbs }) {
-  const { id: currentTaskId, manual } = currentTask;
-  const { reached, terminus } = currentTask.details;
+  const { id: currentTaskId, manual, reached } = currentTask;
+  const { terminus } = currentTask.details;
   const completed = terminus ? true : currentTask.completed;
   const isOldestTask = taskBreadcrumbs.indexOf(currentTask.id) === 0;
   const isLatestTask = [...taskBreadcrumbs].pop() === currentTask.id;
-  return {
+  const returnObject = {
     currentTaskId, completed, manual, isOldestTask,
     isLatestTask, reached, terminus
+  };
+  for (const [key, value] of Object.entries(returnObject)) {
+    if (value === undefined) {
+      const errorMessage = `getWorkflowStats.${key} is undefined`;
+      console.error(errorMessage);
+      throw new Error([errorMessage]);
+    }
   }
+  return returnObject;
 }
 
 function validateButton(workflowState, enabled, tooltip, onClickAction) {

--- a/lib/actionButtons.test.js
+++ b/lib/actionButtons.test.js
@@ -10,11 +10,13 @@ const id = 'task1';
 
 describe('The "Task Complete" button should', () => {
     describe('if the workflow is !reached', () => {
-        const details = { reached: false, terminus: false };
+        const manual = true;
+        const reached = false;
+        const details = { terminus: false };
         test('always return a disabled button with no onClick Action', () => {
             const completed = true;
             const taskBreadcrumbs = [id];
-            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
             expect(taskCompleteCheckbox(workflowState))
                 .toMatchObject({
                     enabled: false,
@@ -24,11 +26,13 @@ describe('The "Task Complete" button should', () => {
         });
     });
     describe('if the workflow is terminus', () => {
-        const details = { reached: true, terminus: true };
+        const manual = true;
+        const reached = true;
+        const details = { terminus: true };
         test('always return a disabled button with no onClick Action', () => {
             const completed = true;
             const taskBreadcrumbs = [id];
-            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
             expect(taskCompleteCheckbox(workflowState))
                 .toMatchObject({
                     enabled: false,
@@ -38,7 +42,8 @@ describe('The "Task Complete" button should', () => {
         });
     });
     describe('if the workflow is reached and !terminus', () => {
-        const details = { reached: true, terminus: false };
+        const reached = true;
+        const details = { terminus: false };
         describe('if the task isLatestTask in the breadcrumbs', () => {
             const completed = false;
             const enabled = true;
@@ -47,7 +52,7 @@ describe('The "Task Complete" button should', () => {
                 const manual = true;
                 test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
                     const checked = false;
-                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
                         .toMatchObject({
                             enabled, checked,
@@ -59,7 +64,7 @@ describe('The "Task Complete" button should', () => {
                 const manual = false;
                 test('and is incomplete, should return an enabled unchecked button with the toggleCompleteStateLocally onclick action', () => {
                     const checked = false;
-                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
                         .toMatchObject({
                             enabled, checked,
@@ -76,7 +81,7 @@ describe('The "Task Complete" button should', () => {
                 test('and is incomplete, should return an enabled unchecked button with the markTaskAsComplete onclick action', () => {
                     const completed = false;
                     const checked = false;
-                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
                         .toMatchObject({
                             enabled, checked,
@@ -86,7 +91,7 @@ describe('The "Task Complete" button should', () => {
                 test('and is complete, should return an enabled checked button with the markTaskAsIncomplete onclick action', () => {
                     const completed = true;
                     const checked = true;
-                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
                         .toMatchObject({
                             enabled, checked,
@@ -100,14 +105,14 @@ describe('The "Task Complete" button should', () => {
                 test('and is incomplete, should return an disabled unchecked button', () => {
                     const completed = false;
                     const checked = false;
-                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
                         .toMatchObject({ enabled, checked });
                 });
                 test('and is complete, should return an disabled checked button', () => {
                     const completed = true;
                     const checked = true;
-                    const workflowState = { currentTask: { id, manual, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
                     expect(taskCompleteCheckbox(workflowState))
                         .toMatchObject({ enabled, checked });
                 });
@@ -118,39 +123,41 @@ describe('The "Task Complete" button should', () => {
 
 describe('The "Prior Task" button should', () => {
     const manual = true;
-    describe('if the workflow is !reached', () => {
-        const details = { reached: false, terminus: false };
-        test('the "Prior Task" button should be disabled', () => {
-            const completed = true;
-            const taskBreadcrumbs = [id, 'task2'];
-            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
-            expect(priorTaskButton(workflowState))
-                .toMatchObject({ enabled: false, onClickAction: null });
-        });
+    describe('if the workflow is !reached, the "Prior Task" button should be disabled', () => {
+        const reached = false;
+        const details = { terminus: false };
+        const completed = true;
+        const taskBreadcrumbs = [id, 'task2'];
+        const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
+        expect(priorTaskButton(workflowState))
+            .toMatchObject({ enabled: false, onClickAction: null });
     });
     describe('if the task is reached', () => {
         const reached = true;
         describe('if the workflow is terminus', () => {
-            const details = { reached, terminus: true };
+            const completed = true;
+            const details = { terminus: true };
             test('always return a disabled button with no onClick Action', () => {
                 const taskBreadcrumbs = [id];
-                const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                 expect(priorTaskButton(workflowState))
                     .toMatchObject({ enabled: false });
             });
         });
         describe('if the workflow is !terminus', () => {
-            const details = { reached, terminus: false };
+            const details = { terminus: false };
             test('if isOldestTask in the breadcrumbs, should return a disabled button', () => {
+                const completed = true;
                 const taskBreadcrumbs = [id, 'task2'];
-                const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                 expect(priorTaskButton(workflowState))
                     .toMatchObject({ enabled: false });
             })
             describe('if !isOldestTask in the breadcrumbs', () => {
                 test('and if isLatestTask in the breadcrumbs, should return a button with getPreviousTask onclick action', () => {
+                    const completed = true;
                     const taskBreadcrumbs = ['task0', 'task1'];
-                    const workflowState = { currentTask: { id, manual, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                     expect(priorTaskButton(workflowState))
                         .toMatchObject({ onClickAction: actions.getPreviousTask });
                 })
@@ -158,13 +165,13 @@ describe('The "Prior Task" button should', () => {
                     const taskBreadcrumbs = ['task0', id, 'task2'];
                     test('and if task is complete should return a button with onclick getPreviousTask action', () => {
                         const completed = true;
-                        const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+                        const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                         expect(priorTaskButton(workflowState))
                             .toMatchObject({ onClickAction: actions.getPreviousTask });
                     })
                     test('and if task is incomplete should return a button with onclick skipTaskAndGetPreviousTask action', () => {
                         const completed = false;
-                        const workflowState = { currentTask: { id, completed, manual, details }, taskBreadcrumbs };
+                        const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                         expect(priorTaskButton(workflowState))
                             .toMatchObject({ onClickAction: actions.skipTaskAndGetPreviousTask });
                     })
@@ -175,12 +182,14 @@ describe('The "Prior Task" button should', () => {
 });
 
 describe('The "Next Task" button should', () => {
+    const manual = true;
     describe('if the workflow is !reached', () => {
-        const details = { reached: false, terminus: false };
+        const reached = false;
+        const details = { terminus: false };
         test('the "Next Task" button should be disabled', () => {
             const completed = true;
             const taskBreadcrumbs = [id, 'task2'];
-            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
             expect(nextTaskButton(workflowState))
                 .toMatchObject({ enabled: false, onClickAction: null });
         });
@@ -188,19 +197,19 @@ describe('The "Next Task" button should', () => {
     describe('if the task is reached', () => {
         const reached = true;
         test('if the workflow is terminus, should return a disabled button', () => {
-            const details = { reached, terminus: true };
-            const completed = false; // value not important
+            const details = { terminus: true };
+            const completed = false;
             const taskBreadcrumbs = [id, 'task2'];
-            const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+            const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
             expect(nextTaskButton(workflowState))
                 .toMatchObject({ enabled: false });
         });
         describe('if the workflow is !terminus', () => {
-            const details = { reached, terminus: false };
+            const details = { terminus: false };
             test('and if isLatestTask in the breadcrumbs, should return a disabled button', () => {
-                const completed = false; // value not important
+                const completed = false;
                 const taskBreadcrumbs = [id];
-                const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+                const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                 expect(nextTaskButton(workflowState))
                     .toMatchObject({ enabled: false });
             })
@@ -208,13 +217,13 @@ describe('The "Next Task" button should', () => {
                 const taskBreadcrumbs = [id, 'task2'];
                 test('and if the task is complete, should return a button with onclick getNextTask action', () => {
                     const completed = true;
-                    const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                     expect(nextTaskButton(workflowState))
                         .toMatchObject({ onClickAction: actions.getNextTask });
                 })
                 test('and if the task is incomplete, should return a button with onclick skipTaskAndGetNextTask action', () => {
                     const completed = false;
-                    const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+                    const workflowState = { currentTask: { id, completed, manual, details, reached }, taskBreadcrumbs };
                     expect(nextTaskButton(workflowState))
                         .toMatchObject({ onClickAction: actions.skipTaskAndGetNextTask });
                 })
@@ -224,11 +233,13 @@ describe('The "Next Task" button should', () => {
 });
 
 describe('The "What\'s Next" button should', () => {
+    const manual = true;
+    const reached = true;
     const details = { terminus: false };
     test('if the task is complete, should return a button with onclick fetchLatestWorkflowState actions', () => {
         const completed = true;
         const taskBreadcrumbs = [id, 'task2'];
-        const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toMatchObject({
                 enabled: true,
@@ -238,7 +249,7 @@ describe('The "What\'s Next" button should', () => {
     test('if the task is incomplete, should return a button with onclick skipTaskAndFetchLatestWorkflowState actions', () => {
         const completed = false;
         const taskBreadcrumbs = ['task0', id, 'task2'];
-        const workflowState = { currentTask: { id, completed, details }, taskBreadcrumbs };
+        const workflowState = { currentTask: { id, manual, completed, details, reached }, taskBreadcrumbs };
         expect(whatsNextButton(workflowState))
             .toMatchObject({
                 enabled: true,


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/NAV-255
- navigator-ui expected `reached` to be inside the task details object, however the api provides it directly at the task level instead. The bug went into master as the original PR was made before the api was built and was never tested manually in the browser to confirm the api had been designed as expected
- I have also included a validation check inside `getWorkflowStats` to make sure this doesn't happen again by throwing an error if any of the returned values are `undefined`. This involved updating all tests which makes up most of this PR's code changes.