### PR TITLE
Fix missing unique keys

### DIFF
--- a/components/ActionButtons.js
+++ b/components/ActionButtons.js
@@ -28,7 +28,9 @@ function ButtonWithTooltip({ button, buttonComponent }) {
     if (button.tooltip) {
         const tooltip = (
             <Tooltip>
-                {button.tooltip.map(line => <div>{line}</div>)}
+                {button.tooltip.map((line, index) =>
+                    <div key={index}>{line}</div>
+                )}
             </Tooltip>
         )
         return (
@@ -125,7 +127,6 @@ export function MainThreeActionButtons({ workflow, handleClick, showDebugData })
             {buttons.map(button => {
                 const buttonComponent = (
                     <Button
-                        key={button.label}
                         style={button.style}
                         variant="danger"
                         onClick={() => handleClick(button.onClickAction)}
@@ -136,7 +137,11 @@ export function MainThreeActionButtons({ workflow, handleClick, showDebugData })
                         {button.onClickAction && displayStatsData(showDebugData, button.onClickAction)}
                     </Button>
                 )
-                return <ButtonWithTooltip {...{ button, buttonComponent }} />
+                return (
+                    <div key={button.label}>
+                        <ButtonWithTooltip {...{ button, buttonComponent }} />
+                    </div>
+                )
             })}
         </ButtonGroup>
     )


### PR DESCRIPTION
# Problem
We had the following error showing up in browser logs:
```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `MainThreeActionButtons`. See https://reactjs.org/link/warning-keys for more information.
    at ButtonWithTooltip (webpack-internal:///./components/ActionButtons.js:57:21)
    at MainThreeActionButtons (webpack-internal:///./components/ActionButtons.js:192:24)
    at div

...

Check the render method of `ButtonWithTooltip`. See https://reactjs.org/link/warning-keys for more information.
    at div
    at ButtonWithTooltip (webpack-internal:///./components/ActionButtons.js:57:21)
    at div
```

# Solution
- Make sure all components in `components/ActionButtons.js` have unique keys