### PR TITLE
NAV-121-add-datasetId-and-taskId-to-url

### DIFF
--- a/components/AuthWrapper.js
+++ b/components/AuthWrapper.js
@@ -42,7 +42,11 @@ export default function AuthWrapper({ Component, pageProps }) {
             userDetailsError && userDetailsError.message.includes('401')
             || datasetsError && datasetsError.message.includes('401')
         if (invalidAuthError) {
-            router.push('/login', undefined, { locale });
+            const url = {
+                pathname: '/login',
+                query: { redirectPath: router.asPath }
+            };
+            router.push(url, undefined, { locale });
             return null;
         } else {
             return <ErrorPagePopup apiError={userDetailsError || datasetsError} />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -13,7 +13,7 @@ import '../styles/globals.css';
 import 'react-loading-skeleton/dist/skeleton.css';
 
 export default function MyApp({ Component, pageProps }) {
-  const { asPath, locale } = useRouter();
+  const { pathname, locale } = useRouter();
   const insecurePages = ['/login', '/logout', '/no_datasets'];
 
   useEffect(async () => {
@@ -28,7 +28,7 @@ export default function MyApp({ Component, pageProps }) {
       >
         <title>{t`HIV Estimates Navigator`}</title>
         <GoogleAnalyticsComponent />
-        {insecurePages.includes(asPath)
+        {insecurePages.includes(pathname)
           ? <Component {...pageProps} />
           : <AuthWrapper {...{ Component, pageProps }} />
         }

--- a/pages/login.js
+++ b/pages/login.js
@@ -20,6 +20,7 @@ const logos = [
 export default function Login() {
     const router = useRouter();
     const { locale } = router;
+    const { redirectPath } = router.query;
     const useAxios = makeUseAxios(baseAxiosConfig(locale));
 
     const [
@@ -45,7 +46,7 @@ export default function Login() {
     }
 
     if (loginState) {
-        router.push('/', undefined, { locale });
+        router.push(redirectPath || '/', undefined, { locale });
         return null;
     }
     const handleSubmit = event => {

--- a/pages/tasks.js
+++ b/pages/tasks.js
@@ -43,13 +43,17 @@ export default function TasksPage(props) {
     }, [props.currentDatasetId]);
 
     function TaskListInAccordion({ milestone, expanded }) {
+        const redirectToTask = taskId => {
+            const query = { datasetId: props.currentDatasetId, taskId };
+            router.push({ pathname: '/', query }, undefined, { locale });
+        };
         const taskList = (
             <ListGroup>
                 {milestone.tasks.map(task => (
                     <ListGroup.Item
                         action
                         key={task.id}
-                        onClick={() => router.push(`/?redirectToTaskId=${task.id}`)}
+                        onClick={() => redirectToTask(task.id)}
                     >
                         <CheckboxWithLabel
                             checked={task.completed}
@@ -66,12 +70,10 @@ export default function TasksPage(props) {
                         <Accordion.Header>
                             <div style={{ width: '100%' }}>
                                 <h4 className="m-0">
-                                    <h4 className="m-0">
-                                        <CheckboxWithLabel
-                                            checked={milestone.progress === 100}
-                                            label={milestone.title}
-                                        />
-                                    </h4>
+                                    <CheckboxWithLabel
+                                        checked={milestone.progress === 100}
+                                        label={milestone.title}
+                                    />
                                 </h4>
                                 <ProgressBar className="mt-2" style={{ height: 5 }}>
                                     <ProgressBar variant="danger" now={milestone.progress || 1} />


### PR DESCRIPTION
https://fjelltopp.atlassian.net/browse/NAV-121

# Manual tests
- If a user goes to `/`, then the url should update to include `datasetId` and `taskId`
- When a user interacts with the ActionButtons and the current task changes, the query params should update
- When a user uses the dataset selector, the query params should update
- If a user clicks to preview a task on the `/tasks` page, the user should be redirected to the correct task and the query params should update
- If a user has been given a specific url to a dataset and taskid but are not logged in, they should be redirected to the login page and then redirected back to the intended task providing their login succeeds.
- Try all the above tests while testing the locale is also correctly persisted through all redirects.