### PR TITLE
NAV-265-redirect-users-on-unsupported-locales

### DIFF
--- a/locales/config.js
+++ b/locales/config.js
@@ -16,28 +16,16 @@ const ptLocale = {
     emoji: '🇵🇹'
 }
 
-const supportedLocales = [
-    enLocale, frLocale, ptLocale
-]
+const supportedLocales = [enLocale];
+const unsupportedLocales = [frLocale, ptLocale];
+const defaultLocale = supportedLocales[0].id;
 
-// TODO: remove if statement once all locales are supported
-const enableAllLocales = false;
-
-if (enableAllLocales) {
-    module.exports = {
-        supportedLocales,
-        i18n: {
-            locales: supportedLocales.map(locale => locale.id),
-            defaultLocale: enLocale.id
-        }
-    }
-} else {
-    module.exports = {
-        supportedLocales: [enLocale],
-        i18n: {
-            locales: supportedLocales.map(locale => locale.id),
-            defaultLocale: enLocale.id,
-            localeDetection: false
-        }
+module.exports = {
+    supportedLocales,
+    unsupportedLocales,
+    defaultLocale,
+    i18n: {
+        locales: supportedLocales.map(locale => locale.id),
+        defaultLocale
     }
 }

--- a/locales/config.js
+++ b/locales/config.js
@@ -18,7 +18,7 @@ const ptLocale = {
 
 const supportedLocales = [enLocale];
 const unsupportedLocales = [frLocale, ptLocale];
-const defaultLocale = supportedLocales[0].id;
+const defaultLocale = supportedLocales[0];
 
 module.exports = {
     supportedLocales,
@@ -26,6 +26,6 @@ module.exports = {
     defaultLocale,
     i18n: {
         locales: supportedLocales.map(locale => locale.id),
-        defaultLocale
+        defaultLocale: defaultLocale.id
     }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -11,10 +11,11 @@ const moduleExports = {
   reactStrictMode: true,
   ...localesConfig,
   async redirects() {
-    return localesConfig.unsupportedLocales.map(locale => (
+    const { unsupportedLocales, defaultLocale } = localesConfig;
+    return unsupportedLocales.map(locale => (
       {
         source: `/${locale.id}/:path*`,
-        destination: `/${localesConfig.defaultLocale}/:path*`,
+        destination: `/${defaultLocale.id}/:path*`,
         permanent: false
       }
     ))

--- a/next.config.js
+++ b/next.config.js
@@ -8,9 +8,17 @@ const localesConfig = require('./locales/config');
 const { withSentryConfig } = require('@sentry/nextjs');
 
 const moduleExports = {
-  // Your existing module.exports
   reactStrictMode: true,
   ...localesConfig,
+  async redirects() {
+    return localesConfig.unsupportedLocales.map(locale => (
+      {
+        source: `/${locale.id}/:path*`,
+        destination: `/${localesConfig.defaultLocale}/:path*`,
+        permanent: false
+      }
+    ))
+  },
 };
 
 const sentryWebpackPluginOptions = {


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/NAV-265
- Related: https://github.com/fjelltopp/ckanext-unaids/pull/182
- ADR wants to redirect users to `navigator/<locale>/?datasetId=123` however navigator only supports the `en` locale at the moment.
- Attempting to access an unsupported locale gives the user a 404 error. We want to redirect the user to `/en/` as a fail-safe rather than giving a 404 error.
- Navigator should continue to give a 404 error on broken locales though such as `/aaaa/`

