### PR TITLE
NAV-275 better error handling in authorized API requests

### DIFF
--- a/lib/navigatorAPIConfig.js
+++ b/lib/navigatorAPIConfig.js
@@ -25,9 +25,13 @@ export async function authorizedNavigatorAPI(req, res, url, method = 'GET') {
         }
         res.status(200).json(apiResponse.data);
     } catch (error) {
-        res.status(error.status || 500).json({
-            error: error.message
-        });
+        if (error.response) {
+            res.status(error.response.status).json(error.response.data)
+        } else if (error.request) {
+            res.status(500).json(error.request.data)
+        } else {
+            res.status(500).json(error);
+        }
     }
     return req, res
 }


### PR DESCRIPTION
I am currently struggling to get my local navigator to work with Auth0 - things seem to have changed since I last did this and I'm not sure where they are documented.

However, this change should mean that @kforenc can receive the correct error message from the server and better error messages too.