### PR TITLE
NAV-275 Missing ADR account page

### DIFF
--- a/components/AuthWrapper.js
+++ b/components/AuthWrapper.js
@@ -42,10 +42,12 @@ export default function AuthWrapper({ Component, pageProps }) {
 
     if (isLoading) {
         return t`Loading...`;
-    } else if ((userDetailsError || datasetsError) && userDetails != 'user_not_found_in_adr') {
+    } else if ((userDetailsError || datasetsError)) {
+        console.log(userDetailsError)
         const invalidAuthError =
             userDetailsError && userDetailsError.message.includes('401')
             || datasetsError && datasetsError.message.includes('401')
+        const adrUserNotFound = userDetailsError.message.includes('404')
         if (invalidAuthError) {
             const url = {
                 pathname: '/login',
@@ -53,15 +55,14 @@ export default function AuthWrapper({ Component, pageProps }) {
             };
             router.push(url, undefined, { locale });
             return null;
-        } else {
-            return <ErrorPagePopup apiError={userDetailsError || datasetsError} />
-        }
-    } else {
-        if (userDetails == 'user_not_found_in_adr') {
+        } else if (adrUserNotFound) {
             router.push('/user_not_found_in_adr', undefined, { locale });
             return null;
         }
-
+        else {
+            return <ErrorPagePopup apiError={userDetailsError || datasetsError} />
+        }
+    } else {
         if (datasets.datasets.length > 0) {
             const currentDatasetIdIsValid = datasets.datasets
                 .map(dataset => dataset.id).includes(currentDatasetId);

--- a/components/AuthWrapper.js
+++ b/components/AuthWrapper.js
@@ -47,7 +47,7 @@ export default function AuthWrapper({ Component, pageProps }) {
         const invalidAuthError =
             userDetailsError && userDetailsError.message.includes('401')
             || datasetsError && datasetsError.message.includes('401')
-        const adrUserNotFound = userDetailsError.message.includes('404')
+        const adrUserNotFound = userDetailsError && userDetailsError.message.includes('404')
         if (invalidAuthError) {
             const url = {
                 pathname: '/login',

--- a/pages/no_datasets.js
+++ b/pages/no_datasets.js
@@ -18,7 +18,7 @@ export default function NoDatasetsPage() {
             <span>{t`Refresh Page`}</span>
           </Button>
         </Link>
-        <Link href={"/logout"}>
+        <Link href="/api/auth/logout">
           <Button variant="outline-danger">{t`Log Out`}</Button>
         </Link>
       </ButtonGroup>

--- a/pages/user_not_found_in_adr.js
+++ b/pages/user_not_found_in_adr.js
@@ -2,16 +2,35 @@ import { t } from "@lingui/macro";
 import Link from "next/link";
 import { ButtonGroup, Button } from "react-bootstrap";
 import { LogInLayout } from "@/components/Layout";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowsRotate } from "@fortawesome/free-solid-svg-icons";
 
 export default function UserNotFoundInAdrPage() {
   return (
     <LogInLayout>
       <h3>{t`Current user has not been found in ADR.`}</h3>
       <hr />
-      <p>{t`Your ADR account has not yet been used to log into ADR. Please log into ADR and come back here.`}</p>
-        <Link href={process.env.NEXT_PUBLIC_CKAN_SITE_URL + "/user/saml2login"}>
-          <Button variant="outline-danger">{t`Log into ADR`}</Button>
+      <p>{t`Your SSO account has not yet been used to log in to the ADR. Please use the "Go to ADR" button below to
+      visit ADR and get your account created.
+       Then come back here and click "Refresh Page".`}</p>
+      <ButtonGroup size="sm">
+        <a href={process.env.NEXT_PUBLIC_CKAN_SITE_URL + "/user/saml2login"} target="_blank">
+          <Button variant="danger">{t`Go to ADR`}</Button>
+        </a>
+      </ButtonGroup>
+      <br />
+      <br />
+      <ButtonGroup size="sm">
+        <Link href={"/"}>
+          <Button variant="outline-danger">
+            <FontAwesomeIcon icon={faArrowsRotate} className="me-2" />
+            <span>{t`Refresh Page`}</span>
+          </Button>
         </Link>
+        <Link href={"/logout"}>
+          <Button variant="outline-danger">{t`Log Out`}</Button>
+        </Link>
+      </ButtonGroup>
 
     </LogInLayout>
   );

--- a/pages/user_not_found_in_adr.js
+++ b/pages/user_not_found_in_adr.js
@@ -14,7 +14,7 @@ export default function UserNotFoundInAdrPage() {
       visit ADR and get your account created.
        Then come back here and click "Refresh Page".`}</p>
       <ButtonGroup size="sm">
-        <a href={process.env.NEXT_PUBLIC_CKAN_SITE_URL + "/user/saml2login"} target="_blank">
+        <a href={`${process.env.NEXT_PUBLIC_CKAN_SITE_URL}/user/saml2login`} target="_blank">
           <Button variant="danger">{t`Go to ADR`}</Button>
         </a>
       </ButtonGroup>
@@ -27,7 +27,7 @@ export default function UserNotFoundInAdrPage() {
             <span>{t`Refresh Page`}</span>
           </Button>
         </Link>
-        <Link href={"/logout"}>
+        <Link href="/api/auth/logout">
           <Button variant="outline-danger">{t`Log Out`}</Button>
         </Link>
       </ButtonGroup>


### PR DESCRIPTION
With changes done by Chas in https://github.com/fjelltopp/navigator_ui/pull/81 the solution to display user friendly error page was possible to be build upon error status codes.

I've also changed the text in the /user_not_found_in_adr and added additional navigator buttons (refresh page and log out).