### PR TITLE
ADX-283 localize SSO login links

### DIFF
--- a/pages/api/auth/[...auth0].js
+++ b/pages/api/auth/[...auth0].js
@@ -2,9 +2,11 @@ import { handleAuth, handleLogin } from "@auth0/nextjs-auth0";
 
 export default handleAuth({
     async login(req, res) {
+        const locale = req.cookies['NEXT_LOCALE'];
         try {
             await handleLogin(req, res, {
                 authorizationParams: {
+                    language: locale,
                 },
             });
         } catch (error) {


### PR DESCRIPTION
When sending requests to Auth0 the app now reads the cookie looking for `NEXT_LOCALE`, which is set on a locale change in the app. If the cookies doesn't exist, i.e. no change has happened yet, then nothing will get sent to Auth0 and it will default to the Auth0 tenancy default, which is `en`.

This change required me to update the custom login screen in our development Auth0 tenancy as it no longer matched the one in the staging / prod tenancy -  we should really use the Auth0 management API to set up some form of a daily sync or diff of these so dev always matches staging / prod changes and / or vice vera.